### PR TITLE
Rename packages

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/JCAProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/JCAProcessor.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.deployment;
+package io.quarkiverse.ironjacamar.deployment;
 
 import java.util.List;
 import java.util.Set;
@@ -13,10 +13,10 @@ import org.jboss.jandex.IndexView;
 import org.jboss.jca.core.connectionmanager.pool.mcp.SemaphoreArrayListManagedConnectionPool;
 import org.jboss.jca.core.tx.jbossts.TransactionIntegrationImpl;
 
-import io.quarkiverse.jca.api.ResourceEndpoint;
-import io.quarkiverse.jca.runtime.JCARecorder;
-import io.quarkiverse.jca.runtime.connectionmanager.ConnectionManagerProducer;
-import io.quarkiverse.jca.spi.ResourceAdapterSupport;
+import io.quarkiverse.ironjacamar.ResourceAdapterSupport;
+import io.quarkiverse.ironjacamar.ResourceEndpoint;
+import io.quarkiverse.ironjacamar.runtime.JCARecorder;
+import io.quarkiverse.ironjacamar.runtime.connectionmanager.ConnectionManagerProducer;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.arc.processor.DotNames;

--- a/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/ResourceAdapterBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/ResourceAdapterBuildItem.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.deployment;
+package io.quarkiverse.ironjacamar.deployment;
 
 import java.util.HashSet;
 import java.util.Objects;

--- a/integration-tests/src/main/java/io/quarkiverse/ironjacamar/AppResourceAdaptorSupport.java
+++ b/integration-tests/src/main/java/io/quarkiverse/ironjacamar/AppResourceAdaptorSupport.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.it;
+package io.quarkiverse.ironjacamar;
 
 import java.lang.reflect.Method;
 
@@ -19,8 +19,6 @@ import org.apache.activemq.artemis.ra.ActiveMQRAConnectionFactory;
 import org.apache.activemq.artemis.ra.ActiveMQRAManagedConnectionFactory;
 import org.apache.activemq.artemis.ra.ActiveMQResourceAdapter;
 import org.apache.activemq.artemis.ra.inflow.ActiveMQActivationSpec;
-
-import io.quarkiverse.jca.spi.ResourceAdapterSupport;
 
 @Singleton
 public class AppResourceAdaptorSupport implements ResourceAdapterSupport {

--- a/integration-tests/src/main/java/io/quarkiverse/ironjacamar/JcaResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/ironjacamar/JcaResource.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.it;
+package io.quarkiverse.ironjacamar;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;

--- a/integration-tests/src/main/java/io/quarkiverse/ironjacamar/MyMessageEndpoint.java
+++ b/integration-tests/src/main/java/io/quarkiverse/ironjacamar/MyMessageEndpoint.java
@@ -1,9 +1,8 @@
-package io.quarkiverse.jca.it;
+package io.quarkiverse.ironjacamar;
 
 import jakarta.jms.Message;
 import jakarta.jms.MessageListener;
 
-import io.quarkiverse.jca.api.ResourceEndpoint;
 import io.quarkus.logging.Log;
 
 @ResourceEndpoint

--- a/integration-tests/src/test/java/io/quarkiverse/ironjacamar/it/JcaResourceIT.java
+++ b/integration-tests/src/test/java/io/quarkiverse/ironjacamar/it/JcaResourceIT.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.it;
+package io.quarkiverse.ironjacamar.it;
 
 import io.quarkus.test.junit.QuarkusIntegrationTest;
 

--- a/integration-tests/src/test/java/io/quarkiverse/ironjacamar/it/JcaResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/ironjacamar/it/JcaResourceTest.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.it;
+package io.quarkiverse.ironjacamar.it;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/ResourceAdapterSupport.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/ResourceAdapterSupport.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.spi;
+package io.quarkiverse.ironjacamar;
 
 import jakarta.resource.spi.ActivationSpec;
 import jakarta.resource.spi.ResourceAdapter;

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/ResourceEndpoint.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/ResourceEndpoint.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.api;
+package io.quarkiverse.ironjacamar;
 
 import static java.lang.annotation.ElementType.TYPE;
 

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/JCAConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/JCAConfig.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.runtime;
+package io.quarkiverse.ironjacamar.runtime;
 
 import java.util.Map;
 

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/JCARecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/JCARecorder.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.runtime;
+package io.quarkiverse.ironjacamar.runtime;
 
 import java.util.Objects;
 import java.util.Set;
@@ -15,8 +15,8 @@ import jakarta.transaction.TransactionSynchronizationRegistry;
 
 import org.jboss.logging.Logger;
 
-import io.quarkiverse.jca.runtime.endpoint.DefaultMessageEndpointFactory;
-import io.quarkiverse.jca.spi.ResourceAdapterSupport;
+import io.quarkiverse.ironjacamar.ResourceAdapterSupport;
+import io.quarkiverse.ironjacamar.runtime.endpoint.DefaultMessageEndpointFactory;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.InstanceHandle;

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusBootstrapContext.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusBootstrapContext.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.runtime;
+package io.quarkiverse.ironjacamar.runtime;
 
 import java.util.Timer;
 

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusWorkManager.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusWorkManager.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.runtime;
+package io.quarkiverse.ironjacamar.runtime;
 
 import jakarta.resource.spi.work.ExecutionContext;
 import jakarta.resource.spi.work.Work;

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/ResourceAdapterShutdownListener.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/ResourceAdapterShutdownListener.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.runtime;
+package io.quarkiverse.ironjacamar.runtime;
 
 import java.util.Objects;
 import java.util.Set;

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/connectionmanager/ConnectionManagerProducer.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/connectionmanager/ConnectionManagerProducer.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.runtime.connectionmanager;
+package io.quarkiverse.ironjacamar.runtime.connectionmanager;
 
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Disposes;

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DefaultMessageEndpoint.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DefaultMessageEndpoint.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.runtime.endpoint;
+package io.quarkiverse.ironjacamar.runtime.endpoint;
 
 import java.lang.reflect.Method;
 

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DefaultMessageEndpointFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DefaultMessageEndpointFactory.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jca.runtime.endpoint;
+package io.quarkiverse.ironjacamar.runtime.endpoint;
 
 import java.lang.reflect.Method;
 
@@ -9,7 +9,7 @@ import jakarta.resource.spi.endpoint.MessageEndpoint;
 import jakarta.resource.spi.endpoint.MessageEndpointFactory;
 import jakarta.transaction.Transactional;
 
-import io.quarkiverse.jca.spi.ResourceAdapterSupport;
+import io.quarkiverse.ironjacamar.ResourceAdapterSupport;
 import io.quarkus.arc.Arc;
 
 public class DefaultMessageEndpointFactory implements MessageEndpointFactory {


### PR DESCRIPTION
As pointed out by @gsmet in https://quarkusio.zulipchat.com/#narrow/stream/187038-dev/topic/Jakarta.20Connectors/near/386324370: 

- `io.quarkiverse.ironjacamar` is the API package
- `io.quarkiverse.ironjacamar.runtime` is the impl package
- `io.quarkiverse.ironjacamar.deployment` is the root package of the deployment module
