### PR TITLE
Use TransactionLevelSupport in the config and default to XA

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-ironjacamar.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-ironjacamar.adoc
@@ -48,6 +48,26 @@ endif::add-copy-button-to-env-var[]
 |
 
 
+a| [[quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.transaction-support]]`link:#quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.transaction-support[quarkus.ironjacamar.ra.connection-manager.transaction-support]`
+
+`link:#quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.transaction-support[quarkus.ironjacamar."resource-adapter-name".ra.connection-manager.transaction-support]`
+
+
+[.description]
+--
+The transaction support level for the Connection Manager
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_RA_CONNECTION_MANAGER_TRANSACTION_SUPPORT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_RA_CONNECTION_MANAGER_TRANSACTION_SUPPORT+++`
+endif::add-copy-button-to-env-var[]
+-- a|
+`local`, `xa` 
+|`local`
+
+
 a| [[quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.allocation-retry]]`link:#quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.allocation-retry[quarkus.ironjacamar.ra.connection-manager.allocation-retry]`
 
 `link:#quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.allocation-retry[quarkus.ironjacamar."resource-adapter-name".ra.connection-manager.allocation-retry]`

--- a/docs/modules/ROOT/pages/includes/quarkus-ironjacamar.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-ironjacamar.adoc
@@ -48,24 +48,26 @@ endif::add-copy-button-to-env-var[]
 |
 
 
-a| [[quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.transaction-support]]`link:#quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.transaction-support[quarkus.ironjacamar.ra.connection-manager.transaction-support]`
+a| [[quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.transaction-support-level]]`link:#quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.transaction-support-level[quarkus.ironjacamar.ra.connection-manager.transaction-support-level]`
 
-`link:#quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.transaction-support[quarkus.ironjacamar."resource-adapter-name".ra.connection-manager.transaction-support]`
+`link:#quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.transaction-support-level[quarkus.ironjacamar."resource-adapter-name".ra.connection-manager.transaction-support-level]`
 
 
 [.description]
 --
 The transaction support level for the Connection Manager
 
+See the link:https://jakarta.ee/specifications/connectors/2.1/apidocs/jakarta.resource/jakarta/resource/spi/transactionsupport.transactionsupportlevel[TransactionSupportLevel Javadoc] for more information
+
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_RA_CONNECTION_MANAGER_TRANSACTION_SUPPORT+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_RA_CONNECTION_MANAGER_TRANSACTION_SUPPORT_LEVEL+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_IRONJACAMAR_RA_CONNECTION_MANAGER_TRANSACTION_SUPPORT+++`
+Environment variable: `+++QUARKUS_IRONJACAMAR_RA_CONNECTION_MANAGER_TRANSACTION_SUPPORT_LEVEL+++`
 endif::add-copy-button-to-env-var[]
 -- a|
-`local`, `xa` 
-|`local`
+`no-transaction`, `local-transaction`, `xa-transaction` 
+|`xa-transaction`
 
 
 a| [[quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.allocation-retry]]`link:#quarkus-ironjacamar_quarkus.ironjacamar.ra.connection-manager.allocation-retry[quarkus.ironjacamar.ra.connection-manager.allocation-retry]`

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/ConnectionManagerFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/ConnectionManagerFactory.java
@@ -3,6 +3,7 @@ package io.quarkiverse.ironjacamar.runtime;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.resource.spi.ManagedConnectionFactory;
+import jakarta.resource.spi.TransactionSupport;
 
 import org.jboss.jca.common.api.metadata.Defaults;
 import org.jboss.jca.core.api.connectionmanager.ccm.CachedConnectionManager;
@@ -36,27 +37,45 @@ public class ConnectionManagerFactory {
                         poolConfig.sharable(),
                         ManagedConnectionPoolFactory.DEFAULT_IMPLEMENTATION);
         pool.setName("pool-" + id);
-        return new org.jboss.jca.core.connectionmanager.ConnectionManagerFactory()
-                .createTransactional(
-                        config.transactionSupport().toTransactionSupportLevel(),
-                        pool,
-                        null,
-                        null,
-                        Defaults.USE_CCM,
-                        ccm,
-                        Defaults.SHARABLE,
-                        Defaults.ENLISTMENT,
-                        Defaults.CONNECTABLE,
-                        Defaults.TRACKING,
-                        new org.jboss.jca.core.api.management.ConnectionManager(id),
-                        config.flushStrategy(),
-                        config.allocationRetry(),
-                        config.allocationRetryWait().toMillis(),
-                        transactionIntegration,
-                        Defaults.INTERLEAVING,
-                        config.xaResourceTimeout().toSecondsPart(),
-                        Defaults.IS_SAME_RM_OVERRIDE,
-                        Defaults.WRAP_XA_RESOURCE,
-                        Defaults.PAD_XID);
+        var factory = new org.jboss.jca.core.connectionmanager.ConnectionManagerFactory();
+        if (config.transactionSupportLevel() == TransactionSupport.TransactionSupportLevel.NoTransaction) {
+            return factory.createNonTransactional(
+                    config.transactionSupportLevel(),
+                    pool,
+                    null,
+                    null,
+                    Defaults.USE_CCM,
+                    ccm,
+                    Defaults.SHARABLE,
+                    Defaults.ENLISTMENT,
+                    Defaults.CONNECTABLE,
+                    Defaults.TRACKING,
+                    config.flushStrategy(),
+                    config.allocationRetry(),
+                    config.allocationRetryWait().toMillis());
+        } else {
+            return factory
+                    .createTransactional(
+                            config.transactionSupportLevel(),
+                            pool,
+                            null,
+                            null,
+                            Defaults.USE_CCM,
+                            ccm,
+                            Defaults.SHARABLE,
+                            Defaults.ENLISTMENT,
+                            Defaults.CONNECTABLE,
+                            Defaults.TRACKING,
+                            new org.jboss.jca.core.api.management.ConnectionManager(id),
+                            config.flushStrategy(),
+                            config.allocationRetry(),
+                            config.allocationRetryWait().toMillis(),
+                            transactionIntegration,
+                            Defaults.INTERLEAVING,
+                            config.xaResourceTimeout().toSecondsPart(),
+                            Defaults.IS_SAME_RM_OVERRIDE,
+                            Defaults.WRAP_XA_RESOURCE,
+                            Defaults.PAD_XID);
+        }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/ConnectionManagerFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/ConnectionManagerFactory.java
@@ -3,7 +3,6 @@ package io.quarkiverse.ironjacamar.runtime;
 import jakarta.inject.Inject;
 import jakarta.inject.Singleton;
 import jakarta.resource.spi.ManagedConnectionFactory;
-import jakarta.resource.spi.TransactionSupport;
 
 import org.jboss.jca.common.api.metadata.Defaults;
 import org.jboss.jca.core.api.connectionmanager.ccm.CachedConnectionManager;
@@ -39,7 +38,7 @@ public class ConnectionManagerFactory {
         pool.setName("pool-" + id);
         return new org.jboss.jca.core.connectionmanager.ConnectionManagerFactory()
                 .createTransactional(
-                        TransactionSupport.TransactionSupportLevel.XATransaction,
+                        config.transactionSupport().toTransactionSupportLevel(),
                         pool,
                         null,
                         null,

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRuntimeConfig.java
@@ -67,9 +67,13 @@ public interface IronJacamarRuntimeConfig {
     interface ConnectionManagerConfig {
         /**
          * The transaction support level for the Connection Manager
+         * <p>
+         * See the <a href=
+         * "https://jakarta.ee/specifications/connectors/2.1/apidocs/jakarta.resource/jakarta/resource/spi/transactionsupport.transactionsupportlevel">TransactionSupportLevel
+         * Javadoc</a> for more information
          */
-        @WithDefault("local")
-        TransactionSupportConfig transactionSupport();
+        @WithDefault("XATransaction")
+        TransactionSupport.TransactionSupportLevel transactionSupportLevel();
 
         /**
          * The number of times to retry the allocation of a connection
@@ -99,22 +103,6 @@ public interface IronJacamarRuntimeConfig {
          * The pool configuration for the Connection Manager
          */
         PoolConfig pool();
-
-        enum TransactionSupportConfig {
-            LOCAL,
-            XA;
-
-            public TransactionSupport.TransactionSupportLevel toTransactionSupportLevel() {
-                switch (this) {
-                    case LOCAL:
-                        return TransactionSupport.TransactionSupportLevel.LocalTransaction;
-                    case XA:
-                        return TransactionSupport.TransactionSupportLevel.XATransaction;
-                    default:
-                        throw new IllegalStateException("Unsupported transaction support level: " + this);
-                }
-            }
-        }
 
         @ConfigGroup
         interface PoolConfig {

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRuntimeConfig.java
@@ -5,6 +5,8 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
+import jakarta.resource.spi.TransactionSupport;
+
 import org.jboss.jca.common.api.metadata.common.FlushStrategy;
 import org.jboss.jca.core.api.connectionmanager.pool.PoolConfiguration;
 import org.jboss.jca.core.connectionmanager.pool.api.PoolStrategy;
@@ -64,6 +66,12 @@ public interface IronJacamarRuntimeConfig {
     @ConfigGroup
     interface ConnectionManagerConfig {
         /**
+         * The transaction support level for the Connection Manager
+         */
+        @WithDefault("local")
+        TransactionSupportConfig transactionSupport();
+
+        /**
          * The number of times to retry the allocation of a connection
          */
         @WithDefault("5")
@@ -91,6 +99,22 @@ public interface IronJacamarRuntimeConfig {
          * The pool configuration for the Connection Manager
          */
         PoolConfig pool();
+
+        enum TransactionSupportConfig {
+            LOCAL,
+            XA;
+
+            public TransactionSupport.TransactionSupportLevel toTransactionSupportLevel() {
+                switch (this) {
+                    case LOCAL:
+                        return TransactionSupport.TransactionSupportLevel.LocalTransaction;
+                    case XA:
+                        return TransactionSupport.TransactionSupportLevel.XATransaction;
+                    default:
+                        throw new IllegalStateException("Unsupported transaction support level: " + this);
+                }
+            }
+        }
 
         @ConfigGroup
         interface PoolConfig {


### PR DESCRIPTION
- Revert "No need to specify transaction support level for connection manager"
- Use TransactionLevelSupport in the config and default to XA
