### PR TITLE
Exclude org.jboss.ironjacamar:ironjacamar-common-spi

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -50,6 +50,10 @@
           <groupId>org.picketbox</groupId>
           <artifactId>picketbox</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.ironjacamar</groupId>
+          <artifactId>ironjacamar-common-spi</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
This dependency does not seem to be necessary