### PR TITLE
Introduce `quarkus.ironjacamar.max-worker-execute-time`

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/IronJacamarProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/IronJacamarProcessor.java
@@ -32,6 +32,7 @@ import io.quarkiverse.ironjacamar.runtime.ConnectionManagerFactory;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarBuildtimeConfig;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarContainer;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarRecorder;
+import io.quarkiverse.ironjacamar.runtime.IronJacamarRuntimeConfig;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarSupport;
 import io.quarkiverse.ironjacamar.runtime.QuarkusIronJacamarLogger;
 import io.quarkiverse.ironjacamar.runtime.TransactionRecoveryManager;
@@ -282,13 +283,15 @@ class IronJacamarProcessor {
             IronJacamarRecorder recorder,
             CoreVertxBuildItem vertxBuildItem,
             BeanContainerBuildItem beanContainerBuildItem,
-            BuildProducer<ContainerStartedBuildItem> startedProducer) {
+            BuildProducer<ContainerStartedBuildItem> startedProducer,
+            IronJacamarRuntimeConfig runtimeConfig) {
         // Iterate through all resource adapters configured
         for (ContainerCreatedBuildItem container : containers) {
             // Start the resource adapter
             RuntimeValue<Future<String>> futureRuntimeValue = recorder.initResourceAdapter(beanContainerBuildItem.getValue(),
                     container.identifier,
-                    vertxBuildItem.getVertx());
+                    vertxBuildItem.getVertx(),
+                    runtimeConfig);
             startedProducer.produce(new ContainerStartedBuildItem(container.identifier, futureRuntimeValue));
         }
     }

--- a/docs/modules/ROOT/pages/includes/quarkus-ironjacamar.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-ironjacamar.adoc
@@ -29,6 +29,24 @@ endif::add-copy-button-to-env-var[]
 |`false`
 
 
+a| [[quarkus-ironjacamar_quarkus-ironjacamar-max-worker-execute-time]]`link:#quarkus-ironjacamar_quarkus-ironjacamar-max-worker-execute-time[quarkus.ironjacamar.max-worker-execute-time]`
+
+
+[.description]
+--
+The maximum amount of time the worker thread can be blocked. If not specified it assumes the same value as defined by the `quarkus.vertx.max-worker-execute-time` configuration.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_MAX_WORKER_EXECUTE_TIME+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_MAX_WORKER_EXECUTE_TIME+++`
+endif::add-copy-button-to-env-var[]
+--|link:https://docs.oracle.com/javase/8/docs/api/java/time/Duration.html[Duration]
+  link:#duration-note-anchor-{summaryTableId}[icon:question-circle[title=More information about the Duration format]]
+|`${QUARKUS.VERTX.MAX-WORKER-EXECUTE-TIME:60}`
+
+
 a|icon:lock[title=Fixed at build time] [[quarkus-ironjacamar_quarkus-ironjacamar-ra-kind]]`link:#quarkus-ironjacamar_quarkus-ironjacamar-ra-kind[quarkus.ironjacamar.ra.kind]`
 
 `link:#quarkus-ironjacamar_quarkus-ironjacamar-ra-kind[quarkus.ironjacamar."resource-adapter-name".ra.kind]`

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRuntimeConfig.java
@@ -31,6 +31,16 @@ import io.smallrye.config.WithUnnamedKey;
 public interface IronJacamarRuntimeConfig {
 
     /**
+     * The maximum amount of time the worker thread can be blocked.
+     * If not specified it assumes the same value as defined by the <code>quarkus.vertx.max-worker-execute-time</code>
+     * configuration.
+     *
+     * @return the maximum amount of time the worker thread can be blocked
+     */
+    @WithDefault("${quarkus.vertx.max-worker-execute-time:60}")
+    Duration maxWorkerExecuteTime();
+
+    /**
      * Resource Adapters
      *
      * @return the resource adapters


### PR DESCRIPTION
This allows defining the maximum wait time for a worker, useful when a ResourceAdapter takes longer than usual to start.

- See #108
