### PR TITLE
Start ConnectionValidator in the application startup

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/IronJacamarProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/IronJacamarProcessor.java
@@ -29,6 +29,7 @@ import io.quarkiverse.ironjacamar.ResourceAdapterKind;
 import io.quarkiverse.ironjacamar.ResourceAdapterTypes;
 import io.quarkiverse.ironjacamar.ResourceEndpoint;
 import io.quarkiverse.ironjacamar.runtime.ConnectionManagerFactory;
+import io.quarkiverse.ironjacamar.runtime.ConnectionValidatorManager;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarBuildtimeConfig;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarContainer;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarRecorder;
@@ -83,6 +84,7 @@ class IronJacamarProcessor {
                 .build());
         additionalBeans.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClasses(
+                        ConnectionValidatorManager.class,
                         ConnectionManagerFactory.class,
                         IronJacamarSupport.class)
                 .build());

--- a/integration-tests/artemis-jms/src/main/resources/application.properties
+++ b/integration-tests/artemis-jms/src/main/resources/application.properties
@@ -4,6 +4,10 @@ quarkus.ironjacamar.ra.config.connection-parameters=host=localhost;port=61616;pr
 quarkus.ironjacamar.ra.config.user=guest
 quarkus.ironjacamar.ra.config.password=guest
 
+
+# Enable background validation
+quarkus.ironjacamar.ra.cm.pool.config.background-validation=true
+
 #Enable pool metrics
 quarkus.ironjacamar.metrics.enabled=true
 

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/ConnectionValidatorManager.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/ConnectionValidatorManager.java
@@ -1,0 +1,60 @@
+package io.quarkiverse.ironjacamar.runtime;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.jboss.jca.core.connectionmanager.pool.validator.ConnectionValidator;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+
+/**
+ * Starts and stop the ConnectionValidator service
+ */
+@Dependent
+public class ConnectionValidatorManager {
+
+    @Inject
+    ManagedExecutor managedExecutor;
+
+    @Inject
+    IronJacamarRuntimeConfig runtimeConfig;
+
+    private static boolean shouldStartConnectionValidator;
+
+    @PostConstruct
+    void postConstruct() {
+        for (IronJacamarRuntimeConfig.ResourceAdapterOuterNamedConfig value : runtimeConfig.resourceAdapters().values()) {
+            if (value.ra().cm().pool().config().backgroundValidation()) {
+                shouldStartConnectionValidator = true;
+                break;
+            }
+        }
+    }
+
+    /**
+     * Start the ConnectionValidator service
+     */
+    void startConnectionValidator(@Observes StartupEvent event) throws Throwable {
+        if (!shouldStartConnectionValidator) {
+            return;
+        }
+        QuarkusIronJacamarLogger.log.startConnectionValidatorService();
+        // Start the ConnectionValidator service
+        ConnectionValidator instance = ConnectionValidator.getInstance();
+        instance.setExecutorService(managedExecutor);
+        instance.start();
+    }
+
+    void stopConnectionValidator(@Observes ShutdownEvent event) throws Throwable {
+        if (!shouldStartConnectionValidator) {
+            return;
+        }
+        QuarkusIronJacamarLogger.log.stopConnectionValidatorService();
+        // Stop the ConnectionValidator service
+        ConnectionValidator.getInstance().stop();
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusIronJacamarLogger.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusIronJacamarLogger.java
@@ -139,4 +139,19 @@ public interface QuarkusIronJacamarLogger extends BasicLogger {
     @LogMessage(level = WARN)
     @Message(id = 12, value = "The @ResourceAdapterTypes annotation was not found in %s. Injection of ConnectionFactories for this ResourceAdapter will not work")
     void resourceAdapterTypesNotDefined(String type);
+
+    /**
+     * Logs a message indicating that the connection validator service is starting.
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 13, value = "Starting Connection Validator service")
+    void startConnectionValidatorService();
+
+    /**
+     * Logs a message indicating that the connection validator service is stopping.
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 14, value = "Stopping Connection Validator service")
+    void stopConnectionValidatorService();
+
 }


### PR DESCRIPTION
- In order to maintain the pool (as requested in #123), we need the `ConnectionValidator` to run when background validation is enabled for any resource adapter