### PR TITLE
Start IdleRemover in the application startup

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/IronJacamarProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/IronJacamarProcessor.java
@@ -30,6 +30,7 @@ import io.quarkiverse.ironjacamar.ResourceAdapterTypes;
 import io.quarkiverse.ironjacamar.ResourceEndpoint;
 import io.quarkiverse.ironjacamar.runtime.ConnectionManagerFactory;
 import io.quarkiverse.ironjacamar.runtime.ConnectionValidatorManager;
+import io.quarkiverse.ironjacamar.runtime.IdleRemoverManager;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarBuildtimeConfig;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarContainer;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarRecorder;
@@ -85,6 +86,7 @@ class IronJacamarProcessor {
         additionalBeans.produce(AdditionalBeanBuildItem.builder()
                 .addBeanClasses(
                         ConnectionValidatorManager.class,
+                        IdleRemoverManager.class,
                         ConnectionManagerFactory.class,
                         IronJacamarSupport.class)
                 .build());

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IdleRemoverManager.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IdleRemoverManager.java
@@ -1,0 +1,65 @@
+package io.quarkiverse.ironjacamar.runtime;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.jboss.jca.core.connectionmanager.pool.idle.IdleRemover;
+
+import io.quarkus.runtime.ShutdownEvent;
+import io.quarkus.runtime.StartupEvent;
+
+/**
+ * Starts and stop the IdleRemover service
+ */
+@Dependent
+public class IdleRemoverManager {
+
+    @Inject
+    ManagedExecutor managedExecutor;
+
+    @Inject
+    IronJacamarRuntimeConfig runtimeConfig;
+
+    private static Boolean shouldStartIdleRemover;
+
+    @PostConstruct
+    void postConstruct() {
+        if (shouldStartIdleRemover == null) {
+            for (IronJacamarRuntimeConfig.ResourceAdapterOuterNamedConfig value : runtimeConfig.resourceAdapters().values()) {
+                if (value.ra().cm().pool().config().idleTimeoutMinutes() > 0) {
+                    shouldStartIdleRemover = Boolean.TRUE;
+                    break;
+                }
+            }
+        }
+        if (shouldStartIdleRemover == null) {
+            shouldStartIdleRemover = Boolean.FALSE;
+        }
+    }
+
+    /**
+     * Start the ConnectionValidator service
+     */
+    void startIdleRemover(@Observes StartupEvent event) throws Throwable {
+        if (!shouldStartIdleRemover) {
+            return;
+        }
+        QuarkusIronJacamarLogger.log.startIdleRemoverService();
+        // Start the ConnectionValidator service
+        IdleRemover instance = IdleRemover.getInstance();
+        instance.setExecutorService(managedExecutor);
+        instance.start();
+    }
+
+    void stopIdleRemover(@Observes ShutdownEvent event) throws Throwable {
+        if (!shouldStartIdleRemover) {
+            return;
+        }
+        QuarkusIronJacamarLogger.log.stopIdleRemoverService();
+        // Stop the IdleRemover service
+        IdleRemover.getInstance().stop();
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusIronJacamarLogger.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusIronJacamarLogger.java
@@ -154,4 +154,18 @@ public interface QuarkusIronJacamarLogger extends BasicLogger {
     @Message(id = 14, value = "Stopping Connection Validator service")
     void stopConnectionValidatorService();
 
+    /**
+     * Logs a message indicating that the connection validator service is starting.
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 15, value = "Starting Idle Remover service")
+    void startIdleRemoverService();
+
+    /**
+     * Logs a message indicating that the connection validator service is stopping.
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 16, value = "Stopping Idle Remover service")
+    void stopIdleRemoverService();
+
 }

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusIronJacamarLogger.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusIronJacamarLogger.java
@@ -144,28 +144,28 @@ public interface QuarkusIronJacamarLogger extends BasicLogger {
      * Logs a message indicating that the connection validator service is starting.
      */
     @LogMessage(level = INFO)
-    @Message(id = 13, value = "Starting Connection Validator service")
+    @Message(id = 13, value = "Starting JCA Pool Connection Validator service")
     void startConnectionValidatorService();
 
     /**
      * Logs a message indicating that the connection validator service is stopping.
      */
     @LogMessage(level = INFO)
-    @Message(id = 14, value = "Stopping Connection Validator service")
+    @Message(id = 14, value = "Stopping JCA Pool Connection Validator service")
     void stopConnectionValidatorService();
 
     /**
      * Logs a message indicating that the connection validator service is starting.
      */
     @LogMessage(level = INFO)
-    @Message(id = 15, value = "Starting Idle Remover service")
+    @Message(id = 15, value = "Starting JCA Pool Idle Remover service")
     void startIdleRemoverService();
 
     /**
      * Logs a message indicating that the connection validator service is stopping.
      */
     @LogMessage(level = INFO)
-    @Message(id = 16, value = "Stopping Idle Remover service")
+    @Message(id = 16, value = "Stopping JCA Pool Idle Remover service")
     void stopIdleRemoverService();
 
 }


### PR DESCRIPTION
This ensures that the IdleRemover service is started and stopped when the idle-timeout-minutes is higher than 0
