### PR TITLE
Make injectable ConnectionFactories dependent scoped

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/ResourceAdapterTypes.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/ResourceAdapterTypes.java
@@ -14,8 +14,8 @@ public @interface ResourceAdapterTypes {
     /**
      * What types are provided by the ConnectionFactory returned by mcf.createConnectionFactory(cm).
      *
-     * @return the types provided by the ConnectionFactory
+     * @return the types provided by the ConnectionFactory, never empty
      */
-    Class<?>[] connectionFactoryTypes() default {};
+    Class<?>[] connectionFactoryTypes();
 
 }


### PR DESCRIPTION
Once the IdleRemover service starts (introduced in #128), underlying sessions managed by the ConnectionFactories produced from the ResourceAdapters may be closed.

Also, `io.quarkiverse.ironjacamar.ResourceAdapterTypes#connectionFactoryTypes` may never be empty

Register a synthetic bean for each connection factory type
