### PR TITLE
Split release into two workflows

### DIFF
--- a/.github/workflows/release-perform.yml
+++ b/.github/workflows/release-perform.yml
@@ -1,0 +1,23 @@
+name: Quarkiverse Perform Release
+run-name: Perform ${{github.event.inputs.tag || github.ref_name}} Release
+on:
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release'
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  perform-release:
+    name: Perform Release
+    uses: quarkiverse/.github/.github/workflows/perform-release.yml@main
+    secrets: inherit
+    with:
+      version: ${{github.event.inputs.tag || github.ref_name}}

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -16,11 +16,3 @@ jobs:
     if: ${{ github.event.pull_request.merged == true}}
     uses: quarkiverse/.github/.github/workflows/prepare-release.yml@main
     secrets: inherit
-
-  perform-release:
-    name: Perform Release
-    needs: prepare-release
-    uses: quarkiverse/.github/.github/workflows/perform-release.yml@main
-    secrets: inherit
-    with:
-      version: ${{needs.prepare-release.outputs.release-version}}


### PR DESCRIPTION
This splits the release workflow into two separate workflows. 

The `release-perform.yml` is triggered when a tag is pushed or can also be invoked manually (for cases where central isn't behaving properly and a retry may be necessary). 

Note that you can already retry failed steps in the existing release.yml workflow, however it will use the same SHAs for the reusable workflows, meaning that if the workflow has a bug and needs to change, you can't rely on the "Retry Failed Jobs". 