### PR TITLE
Set a JNDI `Reference` in the `ConnectionFactory` to avoid serialization and JNDI lookups

### DIFF
--- a/integration-tests/artemis-jms/src/main/java/io/quarkiverse/ironjacamar/JcaResource.java
+++ b/integration-tests/artemis-jms/src/main/java/io/quarkiverse/ironjacamar/JcaResource.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.ironjacamar;
 
+import javax.naming.Referenceable;
+
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import jakarta.jms.ConnectionFactory;
@@ -83,6 +85,12 @@ public class JcaResource {
         try (JMSContext context = factory.createContext()) {
             return context.getTransacted();
         }
+    }
+
+    @GET
+    @Path("/ref")
+    public String getRef() throws Exception {
+        return "ref=" + ((Referenceable) factory).getReference();
     }
 
 }

--- a/integration-tests/artemis-jms/src/test/java/io/quarkiverse/ironjacamar/it/JcaResourceTest.java
+++ b/integration-tests/artemis-jms/src/test/java/io/quarkiverse/ironjacamar/it/JcaResourceTest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.ironjacamar.it;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 
 import jakarta.transaction.Transactional;
 
@@ -43,6 +44,11 @@ public class JcaResourceTest {
     @Test
     public void testTransacted() {
         given().when().get("/jca/transacted").then().statusCode(200).body(is("true"));
+    }
+
+    @Test
+    public void testRef() {
+        given().when().get("/jca/ref").then().statusCode(200).body(is(not("ref=null")));
     }
 
     @Test


### PR DESCRIPTION
Since the original implementation of the `ConnectionFactory` may require serialization and JNDI lookups, setting a simple `Reference` here would avoid these issues

- It may fix https://issues.apache.org/jira/browse/ARTEMIS-5253
