### PR TITLE
Update Quarkus to version 3.15.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <quarkus.version>3.15.4</quarkus.version>
+    <quarkus.version>3.15.5</quarkus.version>
     <ironjacamar.version>3.0.14.Final</ironjacamar.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
- Upgrade Quarkus framework to version `3.15.5` for improved stability and bug fixes.
