### PR TITLE
Add support for disabling activation specs

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/ironjacamar/test/DisableActivationSpecTest.java
+++ b/deployment/src/test/java/io/quarkiverse/ironjacamar/test/DisableActivationSpecTest.java
@@ -1,0 +1,88 @@
+package io.quarkiverse.ironjacamar.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import jakarta.inject.Inject;
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ActivationSpec;
+import jakarta.resource.spi.ManagedConnectionFactory;
+import jakarta.resource.spi.ResourceAdapter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.ironjacamar.ResourceAdapterFactory;
+import io.quarkiverse.ironjacamar.ResourceAdapterKind;
+import io.quarkiverse.ironjacamar.ResourceAdapterTypes;
+import io.quarkiverse.ironjacamar.runtime.IronJacamarContainer;
+import io.quarkiverse.ironjacamar.test.adapter.TestActivationSpec;
+import io.quarkiverse.ironjacamar.test.adapter.TestConnectionFactory;
+import io.quarkiverse.ironjacamar.test.adapter.TestManagedConnectionFactory;
+import io.quarkiverse.ironjacamar.test.adapter.TestResourceAdapter;
+import io.quarkiverse.ironjacamar.test.adapter.TestResourceEndpoint;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DisableActivationSpecTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(TestResourceAdapterFactory.class,
+                            TestResourceAdapter.class,
+                            TestManagedConnectionFactory.class,
+                            TestActivationSpec.class,
+                            TestConnectionFactory.class,
+                            TestResourceEndpoint.class))
+            .overrideConfigKey("quarkus.ironjacamar.ra.kind", "test")
+            .overrideConfigKey("quarkus.ironjacamar.activation-spec.test.enabled", "false");
+
+    @Inject
+    IronJacamarContainer ironJacamarContainer;
+
+    @Test
+    public void shouldStartResource() {
+        TestResourceAdapterFactory resourceAdapterFactory = (TestResourceAdapterFactory) ironJacamarContainer
+                .getResourceAdapterFactory();
+        TestResourceAdapter testResourceAdapter = (TestResourceAdapter) ironJacamarContainer.getResourceAdapter();
+        assertTrue(testResourceAdapter.isStarted());
+        assertThat(resourceAdapterFactory.getActivationCount()).isEqualTo(0);
+    }
+
+    @ResourceAdapterKind("test")
+    @ResourceAdapterTypes(connectionFactoryTypes = { TestConnectionFactory.class })
+    static class TestResourceAdapterFactory implements ResourceAdapterFactory {
+
+        AtomicInteger activationCount = new AtomicInteger(0);
+
+        @Override
+        public String getProductName() {
+            return "Test Resource Adapter";
+        }
+
+        @Override
+        public ResourceAdapter createResourceAdapter(String id, Map<String, String> config) throws ResourceException {
+            return new TestResourceAdapter();
+        }
+
+        @Override
+        public ManagedConnectionFactory createManagedConnectionFactory(String id, ResourceAdapter adapter)
+                throws ResourceException {
+            return new TestManagedConnectionFactory();
+        }
+
+        @Override
+        public ActivationSpec createActivationSpec(String id, ResourceAdapter adapter, Class<?> type,
+                Map<String, String> config) throws ResourceException {
+            activationCount.incrementAndGet();
+            return new TestActivationSpec(adapter);
+        }
+
+        public int getActivationCount() {
+            return activationCount.get();
+        }
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/ironjacamar/test/adapter/TestResourceEndpoint.java
+++ b/deployment/src/test/java/io/quarkiverse/ironjacamar/test/adapter/TestResourceEndpoint.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.ironjacamar.test.adapter;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.cci.MessageListener;
+import jakarta.resource.cci.Record;
+
+import io.quarkiverse.ironjacamar.ResourceEndpoint;
+
+@ResourceEndpoint(activationSpecConfigKey = "test")
+public class TestResourceEndpoint implements MessageListener {
+
+    @Override
+    public Record onMessage(Record inputData) throws ResourceException {
+        return null;
+    }
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-ironjacamar.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-ironjacamar.adoc
@@ -711,6 +711,25 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
+a| [[quarkus-ironjacamar_quarkus-ironjacamar-activation-spec-enabled]] [.property-path]##link:#quarkus-ironjacamar_quarkus-ironjacamar-activation-spec-enabled[`quarkus.ironjacamar.activation-spec.enabled`]##
+
+`quarkus.ironjacamar.activation-spec."activation-spec-name".enabled`
+
+[.description]
+--
+Enable this activation spec. If the activation spec is disabled, endpoints configured to use this activation spec will be not activated.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_ACTIVATION_SPEC_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_ACTIVATION_SPEC_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-ironjacamar_quarkus-ironjacamar-activation-spec-config-config]] [.property-path]##link:#quarkus-ironjacamar_quarkus-ironjacamar-activation-spec-config-config[`quarkus.ironjacamar.activation-spec.config."config"`]##
 
 `quarkus.ironjacamar.activation-spec."activation-spec-name".config."config"`

--- a/docs/modules/ROOT/pages/includes/quarkus-ironjacamar_quarkus.ironjacamar.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-ironjacamar_quarkus.ironjacamar.adoc
@@ -711,6 +711,25 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`false`
 
+a| [[quarkus-ironjacamar_quarkus-ironjacamar-activation-spec-enabled]] [.property-path]##link:#quarkus-ironjacamar_quarkus-ironjacamar-activation-spec-enabled[`quarkus.ironjacamar.activation-spec.enabled`]##
+
+`quarkus.ironjacamar.activation-spec."activation-spec-name".enabled`
+
+[.description]
+--
+Enable this activation spec. If the activation spec is disabled, endpoints configured to use this activation spec will be not activated.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_IRONJACAMAR_ACTIVATION_SPEC_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_IRONJACAMAR_ACTIVATION_SPEC_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-ironjacamar_quarkus-ironjacamar-activation-spec-config-config]] [.property-path]##link:#quarkus-ironjacamar_quarkus-ironjacamar-activation-spec-config-config[`quarkus.ironjacamar.activation-spec.config."config"`]##
 
 `quarkus.ironjacamar.activation-spec."activation-spec-name".config."config"`

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRuntimeConfig.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRuntimeConfig.java
@@ -439,6 +439,16 @@ public interface IronJacamarRuntimeConfig {
      * The Activation Spec configuration
      */
     interface ActivationSpecConfig {
+
+        /**
+         * Enable this activation spec.
+         * If the activation spec is disabled, endpoints configured to use this activation spec will be not activated.
+         *
+         * @return true if the activation spec is enabled
+         */
+        @WithDefault("true")
+        boolean enabled();
+
         /**
          * The configuration for this resource adapter
          *

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarSupport.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarSupport.java
@@ -115,17 +115,21 @@ public class IronJacamarSupport {
         } catch (ClassNotFoundException e) {
             throw new RuntimeException(e);
         }
+        boolean enabled = true;
         Map<String, String> config = new HashMap<>(buildTimeConfig);
         if (activationSpecConfigId != null) {
             var activationSpecConfig = runtimeConfig.activationSpecs().map().get(activationSpecConfigId);
             if (activationSpecConfig != null) {
+                enabled = activationSpecConfig.enabled();
                 config.putAll(activationSpecConfig.config());
             }
         }
-        try {
-            ijContainer.endpointActivation(endpointClass, containerId, config);
-        } catch (ResourceException e) {
-            throw QuarkusIronJacamarLogger.log.cannotActivateEndpoint(e);
+        if (enabled) {
+            try {
+                ijContainer.endpointActivation(endpointClass, containerId, config);
+            } catch (ResourceException e) {
+                throw QuarkusIronJacamarLogger.log.cannotActivateEndpoint(e);
+            }
         }
     }
 }


### PR DESCRIPTION
- Introduce an `enabled` flag in IronJacamar runtime configuration to control activation spec behavior and its conditional runtime handling.
- Add comprehensive testing for activation spec enable/disable logic, including resource adapter lifecycle and activation tracking.
- Expand documentation to detail the new `quarkus.ironjacamar.activation-spec.enabled` property and its configuration.
