### PR TITLE
call onMessage with Vert.x context

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/IronJacamarProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/IronJacamarProcessor.java
@@ -64,6 +64,7 @@ import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.vertx.core.deployment.CoreVertxBuildItem;
 import io.smallrye.common.annotation.Identifier;
 import io.vertx.core.Future;
+import io.vertx.core.Vertx;
 
 class IronJacamarProcessor {
 
@@ -238,6 +239,7 @@ class IronJacamarProcessor {
                     .addQualifier(qualifier)
                     .unremovable()
                     .createWith(recorder.createContainerFunction(key, raKind.kind()))
+                    .addInjectionPoint(ClassType.create(DotName.createSimple(Vertx.class)))
                     .addInjectionPoint(ClassType.create(DotName.createSimple(IronJacamarSupport.class)))
                     .destroyer(BeanDestroyer.CloseableDestroyer.class);
             // Don't need to specify the identifier if a single Resource Adapter is deployed

--- a/integration-tests/artemis-jms/src/main/java/io/quarkiverse/ironjacamar/MyQueueMessageEndpoint.java
+++ b/integration-tests/artemis-jms/src/main/java/io/quarkiverse/ironjacamar/MyQueueMessageEndpoint.java
@@ -13,7 +13,7 @@ import jakarta.ws.rs.Path;
 import io.quarkus.logging.Log;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.smallrye.common.vertx.VertxContext;
-import io.vertx.mutiny.core.Vertx;
+import io.vertx.core.Vertx;
 
 @Singleton
 @ResourceEndpoint(activationSpecConfigKey = "myqueue")

--- a/integration-tests/artemis-jms/src/main/java/io/quarkiverse/ironjacamar/MyQueueMessageEndpoint.java
+++ b/integration-tests/artemis-jms/src/main/java/io/quarkiverse/ironjacamar/MyQueueMessageEndpoint.java
@@ -12,6 +12,8 @@ import jakarta.ws.rs.Path;
 
 import io.quarkus.logging.Log;
 import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.mutiny.core.Vertx;
 
 @Singleton
 @ResourceEndpoint(activationSpecConfigKey = "myqueue")
@@ -24,6 +26,8 @@ public class MyQueueMessageEndpoint implements MessageListener {
     @Transactional
     public void onMessage(Message message) {
         try {
+            Log.info("####### Vertx.context = " + Vertx.currentContext());
+            assert VertxContext.isOnDuplicatedContext();
             String body = message.getBody(String.class);
             Log.infof("Received message: %s", body);
             counter.incrementAndGet();

--- a/integration-tests/artemis-jms/src/main/java/io/quarkiverse/ironjacamar/SalesEndpoint.java
+++ b/integration-tests/artemis-jms/src/main/java/io/quarkiverse/ironjacamar/SalesEndpoint.java
@@ -13,7 +13,7 @@ import jakarta.transaction.Transactional;
 import io.quarkus.logging.Log;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.smallrye.common.vertx.VertxContext;
-import io.vertx.mutiny.core.Vertx;
+import io.vertx.core.Vertx;
 
 @ApplicationScoped
 @ResourceEndpoint(activationSpecConfigKey = "sales")

--- a/integration-tests/artemis-jms/src/main/java/io/quarkiverse/ironjacamar/SalesEndpoint.java
+++ b/integration-tests/artemis-jms/src/main/java/io/quarkiverse/ironjacamar/SalesEndpoint.java
@@ -12,6 +12,8 @@ import jakarta.transaction.Transactional;
 
 import io.quarkus.logging.Log;
 import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.smallrye.common.vertx.VertxContext;
+import io.vertx.mutiny.core.Vertx;
 
 @ApplicationScoped
 @ResourceEndpoint(activationSpecConfigKey = "sales")
@@ -27,6 +29,8 @@ public class SalesEndpoint implements MessageListener {
     public void onMessage(Message message) {
         try {
             Log.info("####### QuarkusTransaction.isActive = " + QuarkusTransaction.isActive());
+            Log.info("####### Vertx.context = " + Vertx.currentContext());
+            assert VertxContext.isOnDuplicatedContext();
             String body = message.getBody(String.class);
             Log.infof("######### Received message from Sales queue: %s", body);
             Log.info("######### Redelivered: " + message.getJMSRedelivered());

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarContainer.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarContainer.java
@@ -12,12 +12,14 @@ import org.jboss.jca.core.connectionmanager.ConnectionManager;
 
 import io.quarkiverse.ironjacamar.ResourceAdapterFactory;
 import io.quarkiverse.ironjacamar.runtime.endpoint.DefaultMessageEndpointFactory;
+import io.vertx.core.Vertx;
 
 /**
  * A managed bean that holds the resource adapter, managed connection factory and connection manager.
  */
 public class IronJacamarContainer implements Closeable {
 
+    private final Vertx vertx;
     private final ResourceAdapterFactory resourceAdapterFactory;
     private final ResourceAdapter resourceAdapter;
     private final ManagedConnectionFactory managedConnectionFactory;
@@ -27,17 +29,19 @@ public class IronJacamarContainer implements Closeable {
     /**
      * Constructor
      *
+     * @param vertx
      * @param resourceAdapterFactory The resource adapter factory
      * @param resourceAdapter The resource adapter
      * @param managedConnectionFactory The managed connection factory
      * @param connectionManager The connection manager
      * @param transactionRecoveryManager The transaction recovery manager
      */
-    public IronJacamarContainer(ResourceAdapterFactory resourceAdapterFactory,
+    public IronJacamarContainer(Vertx vertx, ResourceAdapterFactory resourceAdapterFactory,
             ResourceAdapter resourceAdapter,
             ManagedConnectionFactory managedConnectionFactory,
             ConnectionManager connectionManager,
             TransactionRecoveryManager transactionRecoveryManager) {
+        this.vertx = vertx;
         this.resourceAdapterFactory = resourceAdapterFactory;
         this.resourceAdapter = resourceAdapter;
         this.managedConnectionFactory = managedConnectionFactory;
@@ -94,7 +98,8 @@ public class IronJacamarContainer implements Closeable {
             throws ResourceException {
         ActivationSpec activationSpec = resourceAdapterFactory.createActivationSpec(identifier, resourceAdapter, endpointClass,
                 config);
-        DefaultMessageEndpointFactory messageEndpointFactory = new DefaultMessageEndpointFactory(endpointClass, identifier,
+        DefaultMessageEndpointFactory messageEndpointFactory = new DefaultMessageEndpointFactory(vertx, endpointClass,
+                identifier,
                 resourceAdapterFactory);
         resourceAdapter.endpointActivation(messageEndpointFactory, activationSpec);
         if (transactionRecoveryManager.isEnabled()) {

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRecorder.java
@@ -66,7 +66,9 @@ public class IronJacamarRecorder {
         return context -> {
             IronJacamarSupport containerProducer = context
                     .getInjectedReference(IronJacamarSupport.class);
-            return containerProducer.createContainer(id, kind);
+            Vertx vertx = context
+                    .getInjectedReference(Vertx.class);
+            return containerProducer.createContainer(vertx, id, kind);
         };
     }
 

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarSupport.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarSupport.java
@@ -18,6 +18,7 @@ import io.quarkiverse.ironjacamar.ResourceAdapterFactory;
 import io.quarkiverse.ironjacamar.ResourceAdapterKind;
 import io.quarkus.arc.Unremovable;
 import io.smallrye.common.annotation.Identifier;
+import io.vertx.core.Vertx;
 
 /**
  * This class is a producer for {@link IronJacamarContainer} used in the {@link IronJacamarRecorder}
@@ -63,11 +64,12 @@ public class IronJacamarSupport {
     /**
      * Create a container for the given resource adapter
      *
+     * @param vertx
      * @param id The resource adapter id
      * @param kind The resource adapter kind
      * @return The container
      */
-    public IronJacamarContainer createContainer(String id, String kind) {
+    public IronJacamarContainer createContainer(Vertx vertx, String id, String kind) {
         ResourceAdapterFactory resourceAdapterFactory = resourceAdapterFactories.select(ResourceAdapterKind.Literal.of(kind))
                 .get();
         var adapterRuntimeConfig = runtimeConfig.resourceAdapters().get(id);
@@ -94,7 +96,7 @@ public class IronJacamarSupport {
         } catch (ResourceException re) {
             throw QuarkusIronJacamarLogger.log.cannotDeployResourceAdapter(re);
         }
-        return new IronJacamarContainer(resourceAdapterFactory, resourceAdapter, managedConnectionFactory,
+        return new IronJacamarContainer(vertx, resourceAdapterFactory, resourceAdapter, managedConnectionFactory,
                 connectionManager, transactionRecoveryManager);
     }
 

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DuplicatedContextMessageEndpoint.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DuplicatedContextMessageEndpoint.java
@@ -1,0 +1,71 @@
+package io.quarkiverse.ironjacamar.runtime.endpoint;
+
+import java.lang.reflect.Method;
+
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.endpoint.MessageEndpoint;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+
+/**
+ * A {@link MessageEndpointWrapper} implementation that duplicates the given {@link Context}
+ * before invoking delivery methods on the wrapped {@link MessageEndpoint}.
+ * <p>
+ * This class ensures that a separate execution context is used for the delivery of messages,
+ * which helps in isolating and managing the lifecycle of execution contexts.
+ */
+public class DuplicatedContextMessageEndpoint extends MessageEndpointWrapper {
+
+    private final Context rootContext;
+
+    /**
+     * Constructor
+     *
+     * @param delegate The delegated message endpoint
+     * @param rootContext Vert.x root context
+     */
+    public DuplicatedContextMessageEndpoint(MessageEndpoint delegate, Context rootContext) {
+        super(delegate);
+        this.rootContext = rootContext;
+    }
+
+    /**
+     * Prepares the delivery of a message by duplicating the execution context and beginning its dispatch.
+     *
+     * @param method The method that will handle the message delivery. This parameter represents the business
+     *        method on the message endpoint class that is intended to receive the message.
+     * @throws NoSuchMethodException If a method with the specified name and parameters does not exist within the
+     *         message endpoint class.
+     * @throws ResourceException If any error occurs during the preparation for message delivery.
+     */
+    @Override
+    public void beforeDelivery(Method method) throws NoSuchMethodException, ResourceException {
+        ((ContextInternal) rootContext).duplicate().beginDispatch();
+        super.beforeDelivery(method);
+    }
+
+    /**
+     * Completes the delivery process by performing necessary actions in the current execution context.
+     * <p>
+     * This method is invoked after a message has been delivered to the message endpoint. It ensures
+     * the proper management of the execution context by calling the superclass implementation
+     * to trigger any delegate-specific actions and by signaling the end of the dispatch in the
+     * current Vert.x context. This is critical to clean up and conclude the message processing cycle
+     * for the current context.
+     *
+     * @throws ResourceException if an error occurs while completing the delivery process
+     */
+    @Override
+    public void afterDelivery() throws ResourceException {
+        try {
+            super.afterDelivery();
+        } finally {
+            ContextInternal currentContext = (ContextInternal) Vertx.currentContext();
+            if (currentContext != null) {
+                currentContext.endDispatch(null);
+            }
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/TransactionAwareMessageEndpoint.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/TransactionAwareMessageEndpoint.java
@@ -17,26 +17,20 @@ import com.arjuna.ats.jta.UserTransaction;
 import io.quarkus.arc.Arc;
 import io.quarkus.narayana.jta.QuarkusTransaction;
 import io.quarkus.narayana.jta.QuarkusTransactionException;
-import io.vertx.core.Context;
-import io.vertx.core.Vertx;
-import io.vertx.core.impl.ContextInternal;
 
 /**
  * Transaction aware message endpoint for a given {@link XAResource}
  */
 public class TransactionAwareMessageEndpoint implements MessageEndpoint {
 
-    private final Context rootContext;
     private final XAResource xaResource;
 
     /**
      * Constructor
      *
-     * @param rootContext
      * @param xaResource The XA resource
      */
-    public TransactionAwareMessageEndpoint(Context rootContext, XAResource xaResource) {
-        this.rootContext = rootContext;
+    public TransactionAwareMessageEndpoint(XAResource xaResource) {
         this.xaResource = xaResource;
     }
 
@@ -47,7 +41,6 @@ public class TransactionAwareMessageEndpoint implements MessageEndpoint {
      */
     @Override
     public void beforeDelivery(Method method) throws ResourceException {
-        ContextInternal ignoredAlwaysNull = ((ContextInternal) rootContext).duplicate().beginDispatch();
         Arc.container().requestContext().activate();
         QuarkusTransaction.begin();
         try {
@@ -67,7 +60,6 @@ public class TransactionAwareMessageEndpoint implements MessageEndpoint {
      */
     @Override
     public void afterDelivery() {
-        ContextInternal currentContext = (ContextInternal) Vertx.currentContext();
         try {
             int currentStatus = getStatus();
             if (isActive(currentStatus)) {
@@ -82,7 +74,6 @@ public class TransactionAwareMessageEndpoint implements MessageEndpoint {
             if (context.isActive()) {
                 context.deactivate();
             }
-            currentContext.endDispatch(null);
         }
     }
 


### PR DESCRIPTION
Captures a root Vert.x context at endpoint creation and dispatches each onMessage call on a new duplicated context.

This DOES NOT mean that the onMessage caller thread is now a Vert.x thread. The connection factory still manages the caller thread. 

The dispatch is ended on afterDelivery callback because the assumption is that the same thread will call `beforeDelivery`, `onMessage` and the `afterDelivery` methods.