### PR TITLE
Make delegate field accessible to subclasses

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/MessageEndpointWrapper.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/MessageEndpointWrapper.java
@@ -10,7 +10,7 @@ import jakarta.resource.spi.endpoint.MessageEndpoint;
  */
 public abstract class MessageEndpointWrapper implements MessageEndpoint {
 
-    private final MessageEndpoint delegate;
+    protected final MessageEndpoint delegate;
 
     /**
      * Constructor


### PR DESCRIPTION
- Update visibility of `delegate` field in `MessageEndpointWrapper` from private to protected to improve subclass extensibility.
