### PR TITLE
Handle runtime config as RuntimeValue in `IronJacamarRecorder`

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/IronJacamarProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/ironjacamar/deployment/IronJacamarProcessor.java
@@ -34,7 +34,6 @@ import io.quarkiverse.ironjacamar.runtime.IdleRemoverManager;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarBuildtimeConfig;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarContainer;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarRecorder;
-import io.quarkiverse.ironjacamar.runtime.IronJacamarRuntimeConfig;
 import io.quarkiverse.ironjacamar.runtime.IronJacamarSupport;
 import io.quarkiverse.ironjacamar.runtime.QuarkusIronJacamarLogger;
 import io.quarkiverse.ironjacamar.runtime.TransactionRecoveryManager;
@@ -290,15 +289,13 @@ class IronJacamarProcessor {
             IronJacamarRecorder recorder,
             CoreVertxBuildItem vertxBuildItem,
             BeanContainerBuildItem beanContainerBuildItem,
-            BuildProducer<ContainerStartedBuildItem> startedProducer,
-            IronJacamarRuntimeConfig runtimeConfig) {
+            BuildProducer<ContainerStartedBuildItem> startedProducer) {
         // Iterate through all resource adapters configured
         for (ContainerCreatedBuildItem container : containers) {
             // Start the resource adapter
             RuntimeValue<Future<String>> futureRuntimeValue = recorder.initResourceAdapter(beanContainerBuildItem.getValue(),
                     container.identifier,
-                    vertxBuildItem.getVertx(),
-                    runtimeConfig);
+                    vertxBuildItem.getVertx());
             startedProducer.produce(new ContainerStartedBuildItem(container.identifier, futureRuntimeValue));
         }
     }

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRecorder.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarRecorder.java
@@ -48,10 +48,13 @@ import io.vertx.core.Vertx;
 @Recorder
 public class IronJacamarRecorder {
 
+    private final RuntimeValue<IronJacamarRuntimeConfig> runtimeConfig;
+
     /**
      * Constructor
      */
-    public IronJacamarRecorder() {
+    public IronJacamarRecorder(RuntimeValue<IronJacamarRuntimeConfig> runtimeConfig) {
+        this.runtimeConfig = runtimeConfig;
     }
 
     /**
@@ -176,15 +179,14 @@ public class IronJacamarRecorder {
     public RuntimeValue<Future<String>> initResourceAdapter(
             BeanContainer beanContainer,
             String key,
-            Supplier<Vertx> vertxSupplier,
-            IronJacamarRuntimeConfig config) {
+            Supplier<Vertx> vertxSupplier) {
         Vertx vertx = vertxSupplier.get();
         IronJacamarContainer ijContainer = beanContainer.beanInstance(IronJacamarContainer.class, Identifier.Literal.of(key));
         CloneableBootstrapContext bootstrapContext = BootstrapContextCoordinator.getInstance().getDefaultBootstrapContext();
         List<ResourceAdapterLifecycleListener> listeners = Arc.container().select(ResourceAdapterLifecycleListener.class)
                 .stream().toList();
         IronJacamarVerticle verticle = new IronJacamarVerticle(key, ijContainer, bootstrapContext, listeners);
-        Duration maxWorkerExecuteTime = config.maxWorkerExecuteTime();
+        Duration maxWorkerExecuteTime = runtimeConfig.getValue().maxWorkerExecuteTime();
         Future<String> future = vertx.deployVerticle(verticle, new DeploymentOptions()
                 .setWorkerPoolName("jca-worker-pool-" + key)
                 .setWorkerPoolSize(1)


### PR DESCRIPTION
This fixes the following warning: 
```
2025-07-07 11:27:35,037 WARN  [io.qua.deployment] (main) Run time configuration should not be consumed in Build Steps, use RuntimeValue<io.quarkiverse.ironjacamar.runtime.IronJacamarRuntimeConfig> in a @Recorder constructor instead at io.quarkiverse.ironjacamar.runtime.IronJacamarRuntimeConfig runtimeConfig of void io.quarkiverse.ironjacamar.deployment.IronJacamarProcessor.startResourceAdapters(java.util.List,io.quarkiverse.ironjacamar.runtime.IronJacamarRecorder,io.quarkus.vertx.core.deployment.CoreVertxBuildItem,io.quarkus.arc.deployment.BeanContainerBuildItem,io.quarkus.deployment.annotations.BuildProducer,io.quarkiverse.ironjacamar.runtime.IronJacamarRuntimeConfig) of class io.quarkiverse.ironjacamar.deployment.IronJacamarProcessor.
```