### PR TITLE
Bump Quarkus Artemis to 3.8.4

### DIFF
--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -17,7 +17,7 @@
         <module>multiple-artemis-jms</module>
     </modules>
     <properties>
-        <quarkus.artemis.version>3.8.3</quarkus.artemis.version>
+        <quarkus.artemis.version>3.8.4</quarkus.artemis.version>
         <skipITs>true</skipITs>
     </properties>
     <dependencyManagement>


### PR DESCRIPTION
- This contains the fix that gets rid of the warning in recent Quarkus versions: https://github.com/quarkiverse/quarkus-artemis/pull/864