### PR TITLE
Disable Idle Remover in tests and document pool services

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/ironjacamar/test/DisableActivationSpecTest.java
+++ b/deployment/src/test/java/io/quarkiverse/ironjacamar/test/DisableActivationSpecTest.java
@@ -38,7 +38,8 @@ public class DisableActivationSpecTest {
                             TestConnectionFactory.class,
                             TestResourceEndpoint.class))
             .overrideConfigKey("quarkus.ironjacamar.ra.kind", "test")
-            .overrideConfigKey("quarkus.ironjacamar.activation-spec.test.enabled", "false");
+            .overrideConfigKey("quarkus.ironjacamar.activation-spec.test.enabled", "false")
+            .overrideConfigKey("quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes", "0");
 
     @Inject
     IronJacamarContainer ironJacamarContainer;

--- a/deployment/src/test/java/io/quarkiverse/ironjacamar/test/LifecycleTest.java
+++ b/deployment/src/test/java/io/quarkiverse/ironjacamar/test/LifecycleTest.java
@@ -36,7 +36,8 @@ public class LifecycleTest {
                             TestManagedConnectionFactory.class,
                             TestConnectionFactory.class,
                             TestActivationSpec.class))
-            .overrideConfigKey("quarkus.ironjacamar.ra.kind", "test");
+            .overrideConfigKey("quarkus.ironjacamar.ra.kind", "test")
+            .overrideConfigKey("quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes", "0");
 
     @Test
     void shouldInvokePrecondition() {

--- a/deployment/src/test/java/io/quarkiverse/ironjacamar/test/MissingResourceAdapterTypesTest.java
+++ b/deployment/src/test/java/io/quarkiverse/ironjacamar/test/MissingResourceAdapterTypesTest.java
@@ -33,6 +33,7 @@ public class MissingResourceAdapterTypesTest {
                             TestManagedConnectionFactory.class,
                             TestActivationSpec.class))
             .overrideConfigKey("quarkus.ironjacamar.ra.kind", "test")
+            .overrideConfigKey("quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes", "0")
             .setLogRecordPredicate(record -> record.getLevel().intValue() >= Level.FINER.intValue()
                     && record.getMessage().contains("QIJ000012"))
             .assertLogRecords(records -> {

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -263,6 +263,68 @@ public class WaitUntilServiceIsReady implements ResourceAdapterLifecycleListener
 }
 ----
 
+== Connection Pool Services
+
+The extension automatically manages two background services that help maintain healthy connection pools: the *Idle Remover* and the *Connection Validator*.
+
+=== Idle Remover
+
+The Idle Remover periodically scans the connection pool and removes connections that have been idle for longer than the configured timeout.
+This helps free up resources on both the application and the external system.
+
+The Idle Remover is *enabled by default* with a 30-minute timeout.
+It will start automatically if any resource adapter has an `idle-timeout-minutes` value greater than `0`.
+
+To *disable* it, set the idle timeout to `0`:
+
+[source,properties]
+----
+quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes=0
+----
+
+To *configure* a custom timeout (e.g., 15 minutes):
+
+[source,properties]
+----
+quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes=15
+----
+
+=== Connection Validator
+
+The Connection Validator periodically checks the validity of connections in the pool in the background.
+Invalid connections are removed and replaced, ensuring that the application always gets working connections from the pool.
+
+The Connection Validator is *disabled by default*.
+It will start automatically when `background-validation` is set to `true` and `background-validation-millis` is set to a positive value.
+
+To *enable* it:
+
+[source,properties]
+----
+quarkus.ironjacamar.ra.cm.pool.config.background-validation=true
+quarkus.ironjacamar.ra.cm.pool.config.background-validation-millis=30000
+----
+
+To *disable* it (the default):
+
+[source,properties]
+----
+quarkus.ironjacamar.ra.cm.pool.config.background-validation=false
+----
+
+TIP: As an alternative to background validation, you can use `validate-on-match` to validate connections when they are borrowed from the pool.
+This adds latency to each connection request but guarantees a valid connection without requiring a background thread.
+
+=== Named Resource Adapters
+
+When using <<Multiple Resource Adapters>>, each resource adapter can be configured independently:
+
+[source,properties]
+----
+quarkus.ironjacamar.main.ra.cm.pool.config.idle-timeout-minutes=15
+quarkus.ironjacamar.other.ra.cm.pool.config.idle-timeout-minutes=0
+----
+
 [[extension-configuration-reference]]
 == Extension Configuration Reference
 

--- a/integration-tests/artemis-dev-classloader/src/main/resources/application.properties
+++ b/integration-tests/artemis-dev-classloader/src/main/resources/application.properties
@@ -7,3 +7,5 @@ quarkus.ironjacamar.activation-spec.qa.config.rebalance-connections=true
 
 foo/mp-rest/url=${test.url}
 
+# Disable the idle remover service
+quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes=0

--- a/integration-tests/artemis-jms/src/main/resources/application.properties
+++ b/integration-tests/artemis-jms/src/main/resources/application.properties
@@ -8,6 +8,9 @@ quarkus.ironjacamar.ra.config.password=guest
 # Enable background validation
 quarkus.ironjacamar.ra.cm.pool.config.background-validation=true
 
+# Disable the idle remover service
+quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes=0
+
 #Enable pool metrics
 quarkus.ironjacamar.metrics.enabled=true
 

--- a/integration-tests/multiple-artemis-jms/src/main/resources/application.properties
+++ b/integration-tests/multiple-artemis-jms/src/main/resources/application.properties
@@ -18,3 +18,5 @@ quarkus.ironjacamar.other.ra.config.user=guest
 quarkus.ironjacamar.other.ra.config.password=guest
 
 quarkus.log.category."org.apache.activemq.audit".level=WARN
+# Disable the idle remover service
+quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes=0


### PR DESCRIPTION
## Summary
- Disable the Idle Remover service in unit and integration tests by setting `idle-timeout-minutes=0`, preventing background threads from interfering with test execution
- Add a "Connection Pool Services" documentation section explaining the Idle Remover and Connection Validator services, including how to enable, disable, and configure them per resource adapter

## Test plan
- [x] Verify existing tests pass with the Idle Remover disabled
- [x] Review the new documentation section renders correctly