### PR TITLE
Call `ResourceAdapter.endpointDeactivation()` on shutdown

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/ironjacamar/test/EndpointDeactivationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/ironjacamar/test/EndpointDeactivationTest.java
@@ -1,0 +1,126 @@
+package io.quarkiverse.ironjacamar.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import jakarta.inject.Inject;
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ActivationSpec;
+import jakarta.resource.spi.ManagedConnectionFactory;
+import jakarta.resource.spi.ResourceAdapter;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.ironjacamar.ResourceAdapterFactory;
+import io.quarkiverse.ironjacamar.ResourceAdapterKind;
+import io.quarkiverse.ironjacamar.ResourceAdapterTypes;
+import io.quarkiverse.ironjacamar.runtime.IronJacamarContainer;
+import io.quarkiverse.ironjacamar.test.adapter.TestActivationSpec;
+import io.quarkiverse.ironjacamar.test.adapter.TestConnectionFactory;
+import io.quarkiverse.ironjacamar.test.adapter.TestManagedConnectionFactory;
+import io.quarkiverse.ironjacamar.test.adapter.TestResourceAdapter;
+import io.quarkiverse.ironjacamar.test.adapter.TestResourceEndpoint;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that {@link ResourceAdapter#endpointDeactivation} is called for every activated endpoint
+ * when the application shuts down, as required by the JCA specification.
+ *
+ * <p>
+ * This test uses a custom {@link Handler} instead of {@link QuarkusUnitTest#assertLogRecords} because
+ * the deactivation log (QIJ000018) is emitted during CDI bean destruction, which happens inside
+ * {@code RunningQuarkusApplication.close()}. The {@code assertLogRecords} mechanism snapshots log records
+ * <em>before</em> the application is closed, so it cannot capture shutdown-time messages.
+ */
+public class EndpointDeactivationTest {
+
+    private static final String LOGGER_CATEGORY = "io.quarkiverse.ironjacamar.runtime";
+
+    private static final List<LogRecord> shutdownRecords = new CopyOnWriteArrayList<>();
+
+    /**
+     * Captures the endpoint deactivation log message (QIJ000018) emitted during application shutdown.
+     */
+    private static final Handler deactivationHandler = new Handler() {
+        @Override
+        public void publish(LogRecord record) {
+            if (record.getMessage() != null && record.getMessage().contains("QIJ000018")) {
+                shutdownRecords.add(record);
+            }
+        }
+
+        @Override
+        public void flush() {
+        }
+
+        @Override
+        public void close() {
+        }
+    };
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(TestResourceAdapterFactory.class,
+                            TestResourceAdapter.class,
+                            TestManagedConnectionFactory.class,
+                            TestActivationSpec.class,
+                            TestConnectionFactory.class,
+                            TestResourceEndpoint.class))
+            .overrideConfigKey("quarkus.ironjacamar.ra.kind", "test")
+            .overrideConfigKey("quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes", "0")
+            .setBeforeAllCustomizer(() -> {
+                shutdownRecords.clear();
+                Logger.getLogger(LOGGER_CATEGORY).addHandler(deactivationHandler);
+            })
+            .setAfterUndeployListener(() -> {
+                Logger.getLogger(LOGGER_CATEGORY).removeHandler(deactivationHandler);
+                assertThat(shutdownRecords)
+                        .as("ResourceAdapter.endpointDeactivation() should have been called during shutdown")
+                        .isNotEmpty();
+            });
+
+    @Inject
+    IronJacamarContainer ironJacamarContainer;
+
+    @Test
+    public void shouldDeactivateEndpointOnShutdown() {
+        TestResourceAdapter testResourceAdapter = (TestResourceAdapter) ironJacamarContainer.getResourceAdapter();
+        assertTrue(testResourceAdapter.isStarted());
+    }
+
+    @ResourceAdapterKind("test")
+    @ResourceAdapterTypes(connectionFactoryTypes = { TestConnectionFactory.class })
+    static class TestResourceAdapterFactory implements ResourceAdapterFactory {
+
+        @Override
+        public String getProductName() {
+            return "Test Resource Adapter";
+        }
+
+        @Override
+        public ResourceAdapter createResourceAdapter(String id, Map<String, String> config) throws ResourceException {
+            return new TestResourceAdapter();
+        }
+
+        @Override
+        public ManagedConnectionFactory createManagedConnectionFactory(String id, ResourceAdapter adapter)
+                throws ResourceException {
+            return new TestManagedConnectionFactory();
+        }
+
+        @Override
+        public ActivationSpec createActivationSpec(String id, ResourceAdapter adapter, Class<?> type,
+                Map<String, String> config) throws ResourceException {
+            return new TestActivationSpec(adapter);
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarContainer.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/IronJacamarContainer.java
@@ -1,12 +1,15 @@
 package io.quarkiverse.ironjacamar.runtime;
 
 import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 import jakarta.resource.ResourceException;
 import jakarta.resource.spi.ActivationSpec;
 import jakarta.resource.spi.ManagedConnectionFactory;
 import jakarta.resource.spi.ResourceAdapter;
+import jakarta.resource.spi.endpoint.MessageEndpointFactory;
 
 import org.jboss.jca.core.connectionmanager.ConnectionManager;
 
@@ -25,6 +28,7 @@ public class IronJacamarContainer implements Closeable {
     private final ManagedConnectionFactory managedConnectionFactory;
     private final ConnectionManager connectionManager;
     private final TransactionRecoveryManager transactionRecoveryManager;
+    private final List<ActivatedEndpoint> activatedEndpoints = new ArrayList<>();
 
     /**
      * Constructor
@@ -101,7 +105,9 @@ public class IronJacamarContainer implements Closeable {
         DefaultMessageEndpointFactory messageEndpointFactory = new DefaultMessageEndpointFactory(vertx, endpointClass,
                 identifier,
                 resourceAdapterFactory);
+        QuarkusIronJacamarLogger.log.activatingEndpoint(endpointClass.getName());
         resourceAdapter.endpointActivation(messageEndpointFactory, activationSpec);
+        activatedEndpoints.add(new ActivatedEndpoint(messageEndpointFactory, activationSpec));
         if (transactionRecoveryManager.isEnabled()) {
             transactionRecoveryManager.registerForRecovery(resourceAdapter, activationSpec,
                     resourceAdapterFactory.getProductName(), resourceAdapterFactory.getProductVersion());
@@ -113,7 +119,25 @@ public class IronJacamarContainer implements Closeable {
      */
     @Override
     public void close() {
+        for (ActivatedEndpoint endpoint : activatedEndpoints) {
+            QuarkusIronJacamarLogger.log.deactivatingEndpoint(endpoint.factory().getEndpointClass().getName());
+            if (transactionRecoveryManager.isEnabled()) {
+                transactionRecoveryManager.unregisterRecovery(endpoint.spec());
+            }
+            resourceAdapter.endpointDeactivation(endpoint.factory(), endpoint.spec());
+        }
+        activatedEndpoints.clear();
         connectionManager.prepareShutdown();
         connectionManager.shutdown();
+    }
+
+    /**
+     * Holds a {@link MessageEndpointFactory} and its corresponding {@link ActivationSpec} for an activated endpoint,
+     * so that {@link ResourceAdapter#endpointDeactivation} can be called with the same pair during shutdown.
+     *
+     * @param factory the message endpoint factory used during activation
+     * @param spec the activation spec used during activation
+     */
+    private record ActivatedEndpoint(MessageEndpointFactory factory, ActivationSpec spec) {
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusIronJacamarLogger.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/QuarkusIronJacamarLogger.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.ironjacamar.runtime;
 
 import static org.jboss.logging.Logger.Level.INFO;
+import static org.jboss.logging.Logger.Level.TRACE;
 import static org.jboss.logging.Logger.Level.WARN;
 
 import java.lang.invoke.MethodHandles;
@@ -170,5 +171,41 @@ public interface QuarkusIronJacamarLogger extends BasicLogger {
     @LogMessage(level = INFO)
     @Message(id = 16, value = "Stopping JCA Pool Idle Remover service")
     void stopIdleRemoverService();
+
+    /**
+     * Logs a message indicating that an endpoint is being activated.
+     *
+     * @param endpointClass the endpoint class name
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 17, value = "Activating endpoint %s")
+    void activatingEndpoint(String endpointClass);
+
+    /**
+     * Logs a message indicating that an endpoint is being deactivated.
+     *
+     * @param endpointClass the endpoint class name
+     */
+    @LogMessage(level = INFO)
+    @Message(id = 18, value = "Deactivating endpoint %s")
+    void deactivatingEndpoint(String endpointClass);
+
+    /**
+     * Logs a trace message indicating that an XAResourceRecovery has been registered.
+     *
+     * @param activationSpec the activation spec associated with the recovery
+     */
+    @LogMessage(level = TRACE)
+    @Message(id = 19, value = "Registered XAResourceRecovery for %s")
+    void registeredXAResourceRecovery(String activationSpec);
+
+    /**
+     * Logs a trace message indicating that an XAResourceRecovery has been unregistered.
+     *
+     * @param activationSpec the activation spec associated with the recovery
+     */
+    @LogMessage(level = TRACE)
+    @Message(id = 20, value = "Unregistered XAResourceRecovery for %s")
+    void unregisteredXAResourceRecovery(String activationSpec);
 
 }

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/TransactionRecoveryManager.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/TransactionRecoveryManager.java
@@ -1,7 +1,9 @@
 package io.quarkiverse.ironjacamar.runtime;
 
 import java.io.Closeable;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import jakarta.resource.ResourceException;
@@ -25,6 +27,7 @@ public class TransactionRecoveryManager implements Closeable {
     private final RecoveryPlugin recoveryPlugin;
 
     private final Set<XAResourceRecovery> recoverySet = new HashSet<>();
+    private final Map<ActivationSpec, XAResourceRecovery> endpointRecoveryMap = new HashMap<>();
 
     private final boolean enabled;
 
@@ -92,6 +95,28 @@ public class TransactionRecoveryManager implements Closeable {
         XAResourceRecovery xrr = transactionIntegration.createXAResourceRecovery(resourceAdapter, activationSpec, productName,
                 productVersion);
         initialize(xrr);
+        endpointRecoveryMap.put(activationSpec, xrr);
+        QuarkusIronJacamarLogger.log.registeredXAResourceRecovery(activationSpec.toString());
+    }
+
+    /**
+     * Unregister recovery for a specific activation spec. Called during endpoint deactivation.
+     *
+     * @param activationSpec The activation spec to unregister recovery for
+     */
+    public void unregisterRecovery(ActivationSpec activationSpec) {
+        XAResourceRecovery xrr = endpointRecoveryMap.remove(activationSpec);
+        if (xrr != null) {
+            try {
+                xrr.shutdown();
+            } catch (Exception e) {
+                QuarkusIronJacamarLogger.log.errorDuringRecoveryShutdown(e);
+            } finally {
+                transactionIntegration.getRecoveryRegistry().removeXAResourceRecovery(xrr);
+                recoverySet.remove(xrr);
+                QuarkusIronJacamarLogger.log.unregisteredXAResourceRecovery(activationSpec.toString());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
The JCA spec requires that `endpointDeactivation()` be called for every activated endpoint before the resource adapter is stopped. Previously, `IronJacamarContainer.close()` only shut down the `ConnectionManager` without deactivating endpoints.

- Track activated `(MessageEndpointFactory, ActivationSpec)` pairs
- Deactivate all endpoints and unregister `XAResourceRecovery` in `close()`
- Add INFO log messages for endpoint activation (QIJ000017) and deactivation (QIJ000018)
- Add TRACE log messages for `XAResourceRecovery` registration (QIJ000019) and unregistration (QIJ000020)
- Add per-endpoint recovery unregistration following the pattern from `EndpointImpl.deactivate()`
- Add `EndpointDeactivationTest` verifying deactivation occurs on shutdown