### PR TITLE
Fix Artemis groupId relocation warning

### DIFF
--- a/integration-tests/artemis-common/pom.xml
+++ b/integration-tests/artemis-common/pom.xml
@@ -23,11 +23,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-jakarta-ra</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.activemq</groupId>
+            <groupId>org.apache.artemis</groupId>
             <artifactId>artemis-hqclient-protocol</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Update groupId from `org.apache.activemq` to `org.apache.artemis` for `artemis-jakarta-ra` and `artemis-hqclient-protocol` dependencies in the integration tests
- Follows the upstream [Apache Artemis TLP migration](https://artemis.apache.org/artemis-tlp-groupid-migration)

## Test plan
- [x] Build completes without relocation warnings