### PR TITLE
Wrap inbound XAResource with XAResourceWrapperImpl

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -40,6 +40,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/deployment/src/test/java/io/quarkiverse/ironjacamar/test/XAResourceWrappingTest.java
+++ b/deployment/src/test/java/io/quarkiverse/ironjacamar/test/XAResourceWrappingTest.java
@@ -1,0 +1,116 @@
+package io.quarkiverse.ironjacamar.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.withSettings;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import javax.transaction.xa.XAResource;
+
+import jakarta.inject.Inject;
+import jakarta.resource.ResourceException;
+import jakarta.resource.spi.ActivationSpec;
+import jakarta.resource.spi.ManagedConnectionFactory;
+import jakarta.resource.spi.ResourceAdapter;
+import jakarta.resource.spi.endpoint.MessageEndpoint;
+import jakarta.resource.spi.endpoint.MessageEndpointFactory;
+
+import org.jboss.jca.core.spi.transaction.xa.XAResourceWrapper;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.ironjacamar.ResourceAdapterFactory;
+import io.quarkiverse.ironjacamar.ResourceAdapterKind;
+import io.quarkiverse.ironjacamar.ResourceAdapterTypes;
+import io.quarkiverse.ironjacamar.runtime.IronJacamarContainer;
+import io.quarkiverse.ironjacamar.runtime.endpoint.MessageEndpointWrapper;
+import io.quarkiverse.ironjacamar.runtime.endpoint.TransactionAwareMessageEndpoint;
+import io.quarkiverse.ironjacamar.test.adapter.TestActivationSpec;
+import io.quarkiverse.ironjacamar.test.adapter.TestConnectionFactory;
+import io.quarkiverse.ironjacamar.test.adapter.TestManagedConnectionFactory;
+import io.quarkiverse.ironjacamar.test.adapter.TestResourceEndpoint;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Verifies that {@link io.quarkiverse.ironjacamar.runtime.endpoint.DefaultMessageEndpointFactory#createEndpoint(XAResource)}
+ * wraps the inbound XAResource in an {@link XAResourceWrapper}.
+ * <p>
+ * This prevents Narayana from attempting to serialize the resource adapter's XAResource
+ * during the 2PC prepare phase. Resource adapters like IBM MQ 10 provide XAResource
+ * implementations that declare {@link Serializable} but contain non-serializable fields,
+ * causing the transaction to abort.
+ */
+public class XAResourceWrappingTest {
+
+    static final AtomicReference<MessageEndpointFactory> capturedEndpointFactory = new AtomicReference<>();
+    static final AtomicReference<XAResource> capturedXAResource = new AtomicReference<>();
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(
+                            TestResourceAdapterFactory.class,
+                            TestManagedConnectionFactory.class,
+                            TestConnectionFactory.class,
+                            TestActivationSpec.class,
+                            TestResourceEndpoint.class))
+            .overrideConfigKey("quarkus.ironjacamar.ra.kind", "test")
+            .overrideConfigKey("quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes", "0");
+
+    @Inject
+    IronJacamarContainer container;
+
+    @Test
+    void createEndpointShouldWrapXAResource() throws Exception {
+        XAResource serializableXAResource = mock(XAResource.class, withSettings().extraInterfaces(Serializable.class));
+        capturedEndpointFactory.get().createEndpoint(serializableXAResource);
+        assertThat(capturedXAResource.get())
+                .isInstanceOf(XAResourceWrapper.class)
+                .isNotInstanceOf(Serializable.class);
+    }
+
+    @ResourceAdapterKind("test")
+    @ResourceAdapterTypes(connectionFactoryTypes = TestConnectionFactory.class)
+    static class TestResourceAdapterFactory implements ResourceAdapterFactory {
+
+        @Override
+        public String getProductName() {
+            return "Test Resource Adapter";
+        }
+
+        @Override
+        public ResourceAdapter createResourceAdapter(String id, Map<String, String> config) throws ResourceException {
+            ResourceAdapter adapter = mock(ResourceAdapter.class);
+            doAnswer(invocation -> {
+                capturedEndpointFactory.set(invocation.getArgument(0));
+                return null;
+            }).when(adapter).endpointActivation(any(), any());
+            return adapter;
+        }
+
+        @Override
+        public ManagedConnectionFactory createManagedConnectionFactory(String id, ResourceAdapter adapter) {
+            return new TestManagedConnectionFactory();
+        }
+
+        @Override
+        public ActivationSpec createActivationSpec(String id, ResourceAdapter adapter, Class<?> type,
+                Map<String, String> config) {
+            return new TestActivationSpec(adapter);
+        }
+
+        @Override
+        public MessageEndpoint wrap(MessageEndpoint endpoint, Object resourceEndpoint) {
+            if (endpoint instanceof MessageEndpointWrapper wrapper
+                    && wrapper.unwrap() instanceof TransactionAwareMessageEndpoint txEndpoint) {
+                capturedXAResource.set(txEndpoint.getXAResource());
+            }
+            return endpoint;
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DefaultMessageEndpointFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DefaultMessageEndpointFactory.java
@@ -10,6 +10,8 @@ import jakarta.resource.spi.endpoint.MessageEndpoint;
 import jakarta.resource.spi.endpoint.MessageEndpointFactory;
 import jakarta.transaction.Transactional;
 
+import org.jboss.jca.core.tx.jbossts.XAResourceWrapperImpl;
+
 import io.quarkiverse.ironjacamar.Defaults;
 import io.quarkiverse.ironjacamar.ResourceAdapterFactory;
 import io.quarkus.arc.Arc;
@@ -33,6 +35,7 @@ public class DefaultMessageEndpointFactory implements MessageEndpointFactory {
     /**
      * Constructor
      *
+     * @param vertx The Vert.x instance
      * @param endpointClass The endpoint class
      * @param identifier The identifier
      * @param adapterFactory The resource adapter factory
@@ -73,7 +76,10 @@ public class DefaultMessageEndpointFactory implements MessageEndpointFactory {
         if (xaResource == null) {
             endpoint = NoopMessageEndpoint.INSTANCE;
         } else {
-            endpoint = new TransactionAwareMessageEndpoint(xaResource);
+            // Wrap to prevent Narayana from attempting to serialize the RA's XAResource during 2PC prepare
+            XAResource wrappedXaResource = new XAResourceWrapperImpl(xaResource,
+                    resourceAdapterSupport.getProductName(), resourceAdapterSupport.getProductVersion());
+            endpoint = new TransactionAwareMessageEndpoint(wrappedXaResource);
         }
         // When running in dev mode, we don't want to wrap the endpoint
         if (LaunchMode.current() != LaunchMode.NORMAL) {

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/MessageEndpointWrapper.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/MessageEndpointWrapper.java
@@ -22,6 +22,19 @@ public abstract class MessageEndpointWrapper implements MessageEndpoint {
     }
 
     /**
+     * Unwrap the endpoint wrapper chain and return the underlying implementation.
+     *
+     * @return The innermost message endpoint
+     */
+    public MessageEndpoint unwrap() {
+        MessageEndpoint current = delegate;
+        while (current instanceof MessageEndpointWrapper wrapper) {
+            current = wrapper.delegate;
+        }
+        return current;
+    }
+
+    /**
      * Calls the delegate {@link MessageEndpoint#beforeDelivery(Method)} method.
      */
     @Override

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/TransactionAwareMessageEndpoint.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/TransactionAwareMessageEndpoint.java
@@ -35,6 +35,15 @@ public class TransactionAwareMessageEndpoint implements MessageEndpoint {
     }
 
     /**
+     * Get the XA resource
+     *
+     * @return The XA resource
+     */
+    public XAResource getXAResource() {
+        return xaResource;
+    }
+
+    /**
      * Initiate a transaction and enlist the XA Resource only if @Transactional is present on the endpoint method
      *
      * @param method The method


### PR DESCRIPTION
## Summary

Wraps the inbound `XAResource` provided by the resource adapter in `XAResourceWrapperImpl` before passing it to `TransactionAwareMessageEndpoint`. This prevents Narayana from attempting to serialize the resource adapter's `XAResource` during the 2PC prepare phase, which fails for resource adapters like IBM MQ 10.0.0.0 that declare `Serializable` but contain non-serializable fields.

## Test plan

- [x] Verified `quarkus-ibm-mq` integration tests pass with IBM MQ 9.4.5.1
- [x] Verified `quarkus-ibm-mq` integration tests pass with IBM MQ 10.0.0.0 (previously failing)