### PR TITLE
Exclude jboss-logging-processor transitive dependency

### DIFF
--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -54,6 +54,10 @@
           <groupId>org.jboss.ironjacamar</groupId>
           <artifactId>ironjacamar-common-spi</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.jboss.logging</groupId>
+          <artifactId>jboss-logging-processor</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
   </dependencies>


### PR DESCRIPTION
## Summary

- Exclude `org.jboss.logging:jboss-logging-processor` from `ironjacamar-core-impl` transitive dependencies in the runtime module
- This is a build-time annotation processor used during IronJacamar's own build, not needed at runtime
- Also removes the unnecessary transitive `org.jboss.jdeparser:jdeparser` dependency
- The project already declares `jboss-logging-processor` in the compiler plugin's `annotationProcessorPaths` where it is actually needed

## Test plan

- [x] Full `mvn install -DskipTests` build passes
- [x] Verified `jboss-logging-processor` and `jdeparser` are no longer in `dependency:tree`
- [ ] CI integration tests pass