### PR TITLE
Fix context dispatch lifecycle in DuplicatedContextMessageEndpoint

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/ironjacamar/test/DuplicatedContextRestorationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/ironjacamar/test/DuplicatedContextRestorationTest.java
@@ -75,6 +75,12 @@ public class DuplicatedContextRestorationTest {
                 .isSameAs(outerContext);
 
         endpoint.beforeDelivery(MessageListener.class.getMethod("onMessage", Record.class));
+
+        assertThat(Vertx.currentContext())
+                .as("during delivery, context should be a different (duplicated) instance")
+                .isNotNull()
+                .isNotSameAs(outerContext);
+
         endpoint.afterDelivery();
 
         assertThat(Vertx.currentContext())

--- a/deployment/src/test/java/io/quarkiverse/ironjacamar/test/DuplicatedContextRestorationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/ironjacamar/test/DuplicatedContextRestorationTest.java
@@ -1,0 +1,125 @@
+package io.quarkiverse.ironjacamar.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import jakarta.inject.Inject;
+import jakarta.resource.ResourceException;
+import jakarta.resource.cci.MessageListener;
+import jakarta.resource.cci.Record;
+import jakarta.resource.spi.ActivationSpec;
+import jakarta.resource.spi.ManagedConnectionFactory;
+import jakarta.resource.spi.ResourceAdapter;
+import jakarta.resource.spi.endpoint.MessageEndpoint;
+import jakarta.resource.spi.endpoint.MessageEndpointFactory;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.ironjacamar.ResourceAdapterFactory;
+import io.quarkiverse.ironjacamar.ResourceAdapterKind;
+import io.quarkiverse.ironjacamar.ResourceAdapterTypes;
+import io.quarkiverse.ironjacamar.test.adapter.TestActivationSpec;
+import io.quarkiverse.ironjacamar.test.adapter.TestConnectionFactory;
+import io.quarkiverse.ironjacamar.test.adapter.TestManagedConnectionFactory;
+import io.quarkiverse.ironjacamar.test.adapter.TestResourceEndpoint;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.impl.ContextInternal;
+
+/**
+ * Verifies that {@link io.quarkiverse.ironjacamar.runtime.endpoint.DuplicatedContextMessageEndpoint}
+ * correctly restores the previous Vert.x thread-local context after message delivery.
+ * <p>
+ * The {@code beforeDelivery}/{@code afterDelivery} lifecycle must:
+ * <ul>
+ * <li>Store the duplicated context so that {@code endDispatch} is called on the same instance</li>
+ * <li>Capture and restore the previous thread-local context rather than always clearing it to {@code null}</li>
+ * </ul>
+ */
+public class DuplicatedContextRestorationTest {
+
+    static final AtomicReference<MessageEndpointFactory> capturedEndpointFactory = new AtomicReference<>();
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root
+                    .addClasses(
+                            TestResourceAdapterFactory.class,
+                            TestManagedConnectionFactory.class,
+                            TestConnectionFactory.class,
+                            TestActivationSpec.class,
+                            TestResourceEndpoint.class))
+            .overrideConfigKey("quarkus.ironjacamar.ra.kind", "test")
+            .overrideConfigKey("quarkus.ironjacamar.ra.cm.pool.config.idle-timeout-minutes", "0");
+
+    @Inject
+    Vertx vertx;
+
+    @Test
+    void afterDeliveryShouldRestorePreviousContext() throws Exception {
+        MessageEndpoint endpoint = capturedEndpointFactory.get().createEndpoint(null);
+
+        // Simulate a pre-existing Vert.x context on the current thread
+        Context outerContext = vertx.getOrCreateContext();
+        ContextInternal outerContextInternal = (ContextInternal) outerContext;
+        ContextInternal previous = outerContextInternal.beginDispatch();
+        Context afterDeliveryContext;
+        try {
+            assertThat(Vertx.currentContext())
+                    .as("outer context should be set before delivery")
+                    .isSameAs(outerContext);
+
+            endpoint.beforeDelivery(MessageListener.class.getMethod("onMessage", Record.class));
+            endpoint.afterDelivery();
+
+            afterDeliveryContext = Vertx.currentContext();
+        } finally {
+            // Guard cleanup: the buggy code wipes the thread-local, making endDispatch crash
+            if (Vertx.currentContext() != null) {
+                outerContextInternal.endDispatch(previous);
+            }
+        }
+
+        assertThat(afterDeliveryContext)
+                .as("outer context should be restored after delivery")
+                .isSameAs(outerContext);
+    }
+
+    @ResourceAdapterKind("test")
+    @ResourceAdapterTypes(connectionFactoryTypes = TestConnectionFactory.class)
+    static class TestResourceAdapterFactory implements ResourceAdapterFactory {
+
+        @Override
+        public String getProductName() {
+            return "Test Resource Adapter";
+        }
+
+        @Override
+        public ResourceAdapter createResourceAdapter(String id, Map<String, String> config) throws ResourceException {
+            ResourceAdapter adapter = mock(ResourceAdapter.class);
+            doAnswer(invocation -> {
+                capturedEndpointFactory.set(invocation.getArgument(0));
+                return null;
+            }).when(adapter).endpointActivation(any(), any());
+            return adapter;
+        }
+
+        @Override
+        public ManagedConnectionFactory createManagedConnectionFactory(String id, ResourceAdapter adapter) {
+            return new TestManagedConnectionFactory();
+        }
+
+        @Override
+        public ActivationSpec createActivationSpec(String id, ResourceAdapter adapter, Class<?> type,
+                Map<String, String> config) {
+            return new TestActivationSpec(adapter);
+        }
+    }
+}

--- a/deployment/src/test/java/io/quarkiverse/ironjacamar/test/DuplicatedContextRestorationTest.java
+++ b/deployment/src/test/java/io/quarkiverse/ironjacamar/test/DuplicatedContextRestorationTest.java
@@ -69,25 +69,15 @@ public class DuplicatedContextRestorationTest {
         // Simulate a pre-existing Vert.x context on the current thread
         Context outerContext = vertx.getOrCreateContext();
         ContextInternal outerContextInternal = (ContextInternal) outerContext;
-        ContextInternal previous = outerContextInternal.beginDispatch();
-        Context afterDeliveryContext;
-        try {
-            assertThat(Vertx.currentContext())
-                    .as("outer context should be set before delivery")
-                    .isSameAs(outerContext);
+        outerContextInternal.beginDispatch();
+        assertThat(Vertx.currentContext())
+                .as("outer context should be set before delivery")
+                .isSameAs(outerContext);
 
-            endpoint.beforeDelivery(MessageListener.class.getMethod("onMessage", Record.class));
-            endpoint.afterDelivery();
+        endpoint.beforeDelivery(MessageListener.class.getMethod("onMessage", Record.class));
+        endpoint.afterDelivery();
 
-            afterDeliveryContext = Vertx.currentContext();
-        } finally {
-            // Guard cleanup: the buggy code wipes the thread-local, making endDispatch crash
-            if (Vertx.currentContext() != null) {
-                outerContextInternal.endDispatch(previous);
-            }
-        }
-
-        assertThat(afterDeliveryContext)
+        assertThat(Vertx.currentContext())
                 .as("outer context should be restored after delivery")
                 .isSameAs(outerContext);
     }

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DuplicatedContextMessageEndpoint.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DuplicatedContextMessageEndpoint.java
@@ -6,7 +6,6 @@ import jakarta.resource.ResourceException;
 import jakarta.resource.spi.endpoint.MessageEndpoint;
 
 import io.vertx.core.Context;
-import io.vertx.core.Vertx;
 import io.vertx.core.impl.ContextInternal;
 
 /**
@@ -19,6 +18,8 @@ import io.vertx.core.impl.ContextInternal;
 public class DuplicatedContextMessageEndpoint extends MessageEndpointWrapper {
 
     private final Context rootContext;
+    private ContextInternal duplicatedContext;
+    private ContextInternal previousContext;
 
     /**
      * Constructor
@@ -32,7 +33,10 @@ public class DuplicatedContextMessageEndpoint extends MessageEndpointWrapper {
     }
 
     /**
-     * Prepares the delivery of a message by duplicating the execution context and beginning its dispatch.
+     * Prepares the delivery of a message by duplicating the root context and beginning its dispatch.
+     * <p>
+     * The duplicated context is stored along with the previous thread-local context so that
+     * {@link #afterDelivery()} can restore the original context after message processing completes.
      *
      * @param method The method that will handle the message delivery. This parameter represents the business
      *        method on the message endpoint class that is intended to receive the message.
@@ -42,18 +46,15 @@ public class DuplicatedContextMessageEndpoint extends MessageEndpointWrapper {
      */
     @Override
     public void beforeDelivery(Method method) throws NoSuchMethodException, ResourceException {
-        ((ContextInternal) rootContext).duplicate().beginDispatch();
+        duplicatedContext = ((ContextInternal) rootContext).duplicate();
+        previousContext = duplicatedContext.beginDispatch();
         super.beforeDelivery(method);
     }
 
     /**
-     * Completes the delivery process by performing necessary actions in the current execution context.
-     * <p>
-     * This method is invoked after a message has been delivered to the message endpoint. It ensures
-     * the proper management of the execution context by calling the superclass implementation
-     * to trigger any delegate-specific actions and by signaling the end of the dispatch in the
-     * current Vert.x context. This is critical to clean up and conclude the message processing cycle
-     * for the current context.
+     * Completes the delivery process by ending the dispatch on the duplicated context
+     * and restoring the previous thread-local context that was active before
+     * {@link #beforeDelivery(Method)} was called.
      *
      * @throws ResourceException if an error occurs while completing the delivery process
      */
@@ -62,10 +63,7 @@ public class DuplicatedContextMessageEndpoint extends MessageEndpointWrapper {
         try {
             super.afterDelivery();
         } finally {
-            ContextInternal currentContext = (ContextInternal) Vertx.currentContext();
-            if (currentContext != null) {
-                currentContext.endDispatch(null);
-            }
+            duplicatedContext.endDispatch(previousContext);
         }
     }
 }

--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DuplicatedContextMessageEndpoint.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DuplicatedContextMessageEndpoint.java
@@ -63,7 +63,12 @@ public class DuplicatedContextMessageEndpoint extends MessageEndpointWrapper {
         try {
             super.afterDelivery();
         } finally {
-            duplicatedContext.endDispatch(previousContext);
+            try {
+                duplicatedContext.endDispatch(previousContext);
+            } finally {
+                duplicatedContext = null;
+                previousContext = null;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in `DuplicatedContextMessageEndpoint` where the Vert.x duplicated context dispatch lifecycle was incorrectly implemented:

1. **Lost duplicated context reference** — `beforeDelivery()` called `duplicate().beginDispatch()` as a fire-and-forget chain without storing the duplicated context. This meant `afterDelivery()` had to retrieve the context via `Vertx.currentContext()` instead of using the same instance, which is fragile and incorrect.

2. **Previous context never restored** — `beginDispatch()` returns the previous thread-local context that must be passed back to `endDispatch()` to restore it. The return value was discarded and `endDispatch(null)` always passed `null`, permanently losing any pre-existing context on the thread.

### Fix

Store both the duplicated context and the previous context as instance fields (safe because JCA guarantees `beforeDelivery`/`afterDelivery` run on the same thread for a given message delivery), then call `endDispatch(previousContext)` on the stored duplicated context — matching the pattern used in Quarkus core (e.g., `VertxCoreRecorder`).

## Test plan

- [ ] CI passes (existing integration tests in `artemis-jms` and `multiple-artemis-jms` exercise message endpoint delivery)
- [ ] Verify no regressions in message delivery with transactional and non-transactional endpoints