### PR TITLE
Use VertxContext for dispatch lifecycle instead of ContextInternal

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DuplicatedContextMessageEndpoint.java
+++ b/runtime/src/main/java/io/quarkiverse/ironjacamar/runtime/endpoint/DuplicatedContextMessageEndpoint.java
@@ -5,9 +5,9 @@ import java.lang.reflect.Method;
 import jakarta.resource.ResourceException;
 import jakarta.resource.spi.endpoint.MessageEndpoint;
 
+import io.smallrye.common.vertx.VertxContext;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
-import io.vertx.core.impl.ContextInternal;
 
 /**
  * A {@link MessageEndpointWrapper} implementation that duplicates the given {@link Context}
@@ -42,7 +42,8 @@ public class DuplicatedContextMessageEndpoint extends MessageEndpointWrapper {
      */
     @Override
     public void beforeDelivery(Method method) throws NoSuchMethodException, ResourceException {
-        ((ContextInternal) rootContext).duplicate().beginDispatch();
+        Context duplicated = VertxContext.createNewDuplicatedContext(rootContext);
+        VertxContext.beginDispatch(duplicated);
         super.beforeDelivery(method);
     }
 
@@ -62,9 +63,9 @@ public class DuplicatedContextMessageEndpoint extends MessageEndpointWrapper {
         try {
             super.afterDelivery();
         } finally {
-            ContextInternal currentContext = (ContextInternal) Vertx.currentContext();
+            Context currentContext = Vertx.currentContext();
             if (currentContext != null) {
-                currentContext.endDispatch(null);
+                VertxContext.endDispatch(currentContext, null);
             }
         }
     }


### PR DESCRIPTION
## Summary

- Replace direct `ContextInternal.beginDispatch()` / `endDispatch()` calls in `DuplicatedContextMessageEndpoint` with the new `VertxContext.beginDispatch()` / `VertxContext.endDispatch()` from SmallRye Common
- Also replaces `((ContextInternal) rootContext).duplicate()` with `VertxContext.createNewDuplicatedContext(rootContext)`
- Eliminates the `io.vertx.core.impl.ContextInternal` import entirely

## Why

`ContextInternal` is a Vert.x **internal** API that can change between versions. SmallRye Common's `VertxContext` exists precisely to wrap these internals behind a stable public API. Until now it only covered context *creation* (duplicate, nested, etc.) but not dispatch lifecycle — so this extension had no choice but to use the internal API directly.

SmallRye Common PR [smallrye/smallrye-common#572](https://github.com/smallrye/smallrye-common/pull/572) adds the missing `beginDispatch` / `endDispatch` methods to `VertxContext`, making this cleanup possible.

## Blocked on

- [ ] [smallrye/smallrye-common#572](https://github.com/smallrye/smallrye-common/pull/572) must be merged and released first
- [ ] SmallRye Common dependency version bump in this project

## Test plan

- [ ] Existing integration tests should continue to pass once the SmallRye Common dependency is updated